### PR TITLE
Link taxon information to breadcrumb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ require 'set'
 require 'json'
 
 
-
 task default: [:generate_json]
 
 task :generate_json do
@@ -37,13 +36,14 @@ task :generate_json do
     documents_in_taxon[taxon] = get_documents_by_taxon(taxon_information[taxon]['content_id'])
   end
 
-  pp documents_in_taxon
+  #pp documents_in_taxon
 
   puts(
     JSON.pretty_generate(
       "taxons_for_content" => taxons_for_content,
-"ancestors_of_taxon" => ancestors_of_taxon,
-"taxon_information" => taxon_information
+      "ancestors_of_taxon" => ancestors_of_taxon,
+      "taxon_information" => taxon_information,
+      "documents_in_taxon" => documents_in_taxon
     )
   )
 

--- a/app/data/metadata_and_taxons.json
+++ b/app/data/metadata_and_taxons.json
@@ -1,0 +1,190 @@
+{
+  "taxons_for_content": {
+    "complain-ofsted-report": [
+      "/alpha-taxonomy/inspections"
+    ],
+    "guidance/being-inspected-as-a-childrens-centre-guidance-for-providers": [
+
+    ],
+    "government/statistics/announcements/childcare-providers-and-inspections": [
+      "/alpha-taxonomy/inspections"
+    ],
+    "government/consultations/better-inspection-for-all": [
+      "/alpha-taxonomy/inspections"
+    ],
+    "government/news/consultation-on-radical-changes-to-inspection": [
+      "/alpha-taxonomy/inspections"
+    ],
+    "government/publications/early-years-newsletter-2015": [
+
+    ],
+    "government/statistics/official-statistics-early-years-and-childcare-registered-providers-inspections-and-outcomes": [
+      "/alpha-taxonomy/inspections"
+    ]
+  },
+  "ancestors_of_taxon": {
+    "/alpha-taxonomy/inspections": [
+      {
+        "analytics_identifier": null,
+        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/childcare-and-early-years",
+        "base_path": "/alpha-taxonomy/childcare-and-early-years",
+        "content_id": "502eac33-76ad-499e-b15f-a1544be548c5",
+        "description": null,
+        "document_type": "taxon",
+        "locale": "en",
+        "public_updated_at": "2016-04-15T12:44:37Z",
+        "schema_name": "taxon",
+        "title": "Childcare and early years",
+        "web_url": "https://www.gov.uk/alpha-taxonomy/childcare-and-early-years",
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/education",
+              "base_path": "/alpha-taxonomy/education",
+              "content_id": "9224b0fb-0701-4fb3-a563-1fb744e60359",
+              "description": null,
+              "document_type": "taxon",
+              "locale": "en",
+              "public_updated_at": "2016-01-29T14:58:52Z",
+              "schema_name": "taxon",
+              "title": "Education",
+              "web_url": "https://www.gov.uk/alpha-taxonomy/education",
+              "links": {
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "taxon_information": {
+    "/alpha-taxonomy/inspections": {
+      "title": "Inspections",
+      "content_id": "e184c8d6-7142-4637-ae1e-3270247e0f4f"
+    }
+  },
+  "documents_in_taxon": {
+    "/alpha-taxonomy/inspections": {
+      "results": [
+        {
+          "title": "Find an Ofsted inspection report",
+          "description": "Search for Ofsted inspection reports for childminders and childcare providers, schools, colleges, further education providers, children and families services",
+          "link": "/find-ofsted-inspection-report",
+          "format": "transaction",
+          "public_timestamp": "2014-12-17T10:35:47+00:00",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/find-ofsted-inspection-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "School inspection handbook",
+          "description": "Guidance for inspecting schools under the common inspection framework, with a mythbuster document on common misconceptions.",
+          "link": "/government/publications/school-inspection-handbook-from-september-2015",
+          "format": "publication",
+          "public_timestamp": "2016-08-23T10:58:59.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/school-inspection-handbook-from-september-2015",
+          "document_type": "edition"
+        },
+        {
+          "title": "Common inspection framework: education, skills and early years from September 2015",
+          "description": "How Ofsted inspects maintained schools and academies, non-association independent schools, further education and skills provision and early years settings.",
+          "link": "/government/publications/common-inspection-framework-education-skills-and-early-years-from-september-2015",
+          "format": "publication",
+          "public_timestamp": "2015-08-28T10:30:12.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/common-inspection-framework-education-skills-and-early-years-from-september-2015",
+          "document_type": "edition"
+        },
+        {
+          "title": "Early years inspection handbook from September 2015",
+          "description": "Guidance for inspecting early years providers under the common inspection framework from September 2015.",
+          "link": "/government/publications/early-years-inspection-handbook-from-september-2015",
+          "format": "publication",
+          "public_timestamp": "2015-08-28T10:30:16.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/early-years-inspection-handbook-from-september-2015",
+          "document_type": "edition"
+        },
+        {
+          "title": "Being inspected as a childminder or childcare provider",
+          "description": "Find out when you'll be inspected by Ofsted, how to prepare, how you'll be inspected and how you'll be graded",
+          "link": "/ofsted-inspection-childcare-provider",
+          "format": "answer",
+          "public_timestamp": "2014-11-27T15:14:39+00:00",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/ofsted-inspection-childcare-provider",
+          "document_type": "edition"
+        },
+        {
+          "title": "Inspecting early years providers: online self evaluation form",
+          "description": "Self evaluation form linked to the judgements that Ofsted will make at inspection.",
+          "link": "/government/publications/early-years-online-self-evaluation-form-sef-and-guidance-for-providers-delivering-the-early-years-foundation-stage",
+          "format": "publication",
+          "public_timestamp": "2015-09-24T14:28:15.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/early-years-online-self-evaluation-form-sef-and-guidance-for-providers-delivering-the-early-years-foundation-stage",
+          "document_type": "edition"
+        },
+        {
+          "title": "Disclosure and Barring Service (DBS) checks: childcare providers",
+          "description": "Ofsted’s position on Disclosure and Barring (DBS) checks for childcare providers who register with Ofsted.",
+          "link": "/government/publications/disclosure-and-barring-service-dbs-checks-for-childcare-providers-who-register-with-ofsted",
+          "format": "publication",
+          "public_timestamp": "2014-09-22T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/disclosure-and-barring-service-dbs-checks-for-childcare-providers-who-register-with-ofsted",
+          "document_type": "edition"
+        },
+        {
+          "title": "Inspecting safeguarding in early years, education and skills",
+          "description": "Guidance for Ofsted inspectors to use when inspecting safeguarding under the common inspection framework. ",
+          "link": "/government/publications/inspecting-safeguarding-in-early-years-education-and-skills-from-september-2015",
+          "format": "publication",
+          "public_timestamp": "2016-08-23T09:30:24.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/inspecting-safeguarding-in-early-years-education-and-skills-from-september-2015",
+          "document_type": "edition"
+        },
+        {
+          "title": "Changes to education inspection from September 2015",
+          "description": "Details of the changes to how Ofsted will inspect early years provision, schools and further education and skills from September 2015.",
+          "link": "/guidance/changes-to-education-inspection-from-september-2015",
+          "format": "detailed_guidance",
+          "public_timestamp": "2015-06-15T17:00:00.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/changes-to-education-inspection-from-september-2015",
+          "document_type": "edition"
+        },
+        {
+          "title": "Inspecting registered childcare providers: guidance for inspectors",
+          "description": "Guidance for Ofsted inspectors inspecting providers registered on the compulsory and voluntary parts of the Childcare Register.",
+          "link": "/government/publications/conducting-childcare-register-inspections",
+          "format": "publication",
+          "public_timestamp": "2014-08-20T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/conducting-childcare-register-inspections",
+          "document_type": "edition"
+        }
+      ],
+      "total": 52,
+      "start": 0,
+      "facets": {
+      },
+      "suggested_queries": [
+
+      ]
+    }
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,10 @@ var express = require('express');
 var router = express.Router();
 var fs = require('fs');
 var path = require('path');
+var expressNunjucks = require('express-nunjucks');
+var app = express();
+
+var metadata = getMetadata();
 
 router.get('/', function (req, res) {
 
@@ -36,12 +40,53 @@ router.get('/:url', function (req, res) {
     if (err) {
       throw err;
     }
-
     content = data.toString();
+    breadcrumb = getBreadcrumb(url);
 
-    res.render('content', { content: content });
+    res.render('content', { content: content, breadcrumb: breadcrumb });
   });
+
 });
+
+
+function getMetadata() {
+  fs.readFile('app/data/metadata_and_taxons.json', function(err, data){
+    if (err){
+      console.log('Failed to read metadata and taxons.');
+    }
+    metadata = JSON.parse(data);
+  });
+}
+
+function getBreadcrumb(page) {
+  // Pick the first taxon to generate a breadcrumb from
+  taxonForPage = metadata['taxons_for_content'][page][0];
+
+  taxonAncestors = [
+    {
+      title: metadata['taxon_information'][taxonForPage]['title'],
+      basePath: taxonForPage,
+    }
+  ];
+
+  taxonParents = metadata['ancestors_of_taxon'][taxonForPage];
+
+  while (taxonParents && taxonParents.length > 0) {
+    // Pick the first parent to use in the breadcrumb
+    ancestor = taxonParents[0];
+
+    taxonAncestors.push(
+      {
+        title: ancestor.title,
+        basePath: ancestor.base_path,
+      }
+    );
+
+    taxonParents = ancestor.links.parent;
+  }
+
+  return taxonAncestors.reverse();
+}
 
 // Example routes - feel free to delete these
 

--- a/app/views/_breadcrumb.html
+++ b/app/views/_breadcrumb.html
@@ -1,0 +1,7 @@
+<div class="breadcrumbs">
+  <ol>
+    {% for page in breadcrumb %}
+      <li><a href="{{ page.basePath }}/"> {{ page.title }} </a></li>
+    {% endfor %}
+  </ol>
+</div>

--- a/app/views/content.html
+++ b/app/views/content.html
@@ -1,7 +1,12 @@
 {% extends "layout.html" %}
 
+
 {% block content %}
+
   <div id="wrapper">
+    {% block breadcrumb %}
+      {% include '_breadcrumb.html' %}
+    {% endblock %}
     <div class="grid-row">
       {{ content | safe }}
     </div>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-sync": "^0.5.1",
     "hogan.js": "3.0.2",
     "minimist": "0.0.8",
+    "nunjucks": "^2.4.2",
     "portscanner": "^1.0.0",
     "prompt": "^0.2.14",
     "readdir": "0.0.6",


### PR DESCRIPTION
Paired with Mat.  Add meta-data file generated from generate json rake task which outputs taxons for pages and taxon ancestors.  Add breadcrumb template using taxon information from rake task, included in all content pages.