### PR TITLE
Get all content URLs rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
+    "bluebird": "^3.4.3",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
     "consolidate": "0.x",
@@ -19,6 +20,7 @@
     "express-nunjucks": "^0.9.3",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
+    "glob": "^7.0.5",
     "govuk-elements-sass": "1.2.0",
     "govuk_frontend_toolkit": "^4.15.0",
     "govuk_template_jinja": "0.18.0",


### PR DESCRIPTION
- Use globs to look for html organised by format
- Use regular expressions for the route because some base paths have multiple parts
- Use promises to chain globbing and file operations

At the moment, some URLs look like
/government/statistics/announcements/childcare-providers-and-inspections

and some are just simple URLs like /complain-ofsted-report

We might want to change these paths, because the /government/statistics/announcement
part doesn't tell the user much about where they are. We've kept them the same as the
live site for now though.

We also removed the example routes from the router, as they were cluttering the code.w