### PR TITLE
Dynamically generate recent and popular pages

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -128,13 +128,25 @@ var readFile = Promise.promisify(fs.readFile);
       this.content.push(content);
     }
 
+    popularContent(maxDocuments) {
+      return this.content.slice(0, maxDocuments);
+    }
+
+    atozContent(maxDocuments) {
+      return this.content.sort(function(a, b) {a.title > b.title}).slice(0, maxDocuments);
+    }
+
+    recentContent(maxDocuments) {
+      return this.content.sort(function(a, b) {a.publicTimestamp > b.publicTimestamp}).slice(0, maxDocuments);
+    }
+
     static fromMetadata(basePath) {
       var taxonInformation = metadata.taxon_information[basePath];
       var taxon = new Taxon(taxonInformation.title, basePath);
       var contentItems = metadata.documents_in_taxon[basePath].results;
 
       contentItems.forEach(function(contentItem) {
-        taxon.addContent({title: contentItem.title, basePath: contentItem.link, format: contentItem.format});
+        taxon.addContent({title: contentItem.title, basePath: contentItem.link, format: contentItem.format, publicTimestamp: new Date(contentItem.public_timestamp)});
       });
 
       return taxon;

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -12,50 +12,27 @@
       {% block taxonomy %}
           <h1>{{ taxon.title }}</h1>
           <p>A short description of this topic to make it easier to understand</p>
-
           <nav class="popular-list">
             <h2>Most popular</h2>
             <ol>
+            {% for document in taxon.popularContent(5) %}
                <li>
-                  <a href="/government/publications/school-inspection-handbook-from-september-2015">School inspection handbook</a>
+                 <a href="{{ document.base_path }}">{{ document.title }}</a>
                </li>
-               <li>
-                  <a href="/government/publications/inspecting-safeguarding-in-early-years-education-and-skills-from-september-2015">Inspecting safeguarding in early years, education and skills</a>
-               </li>
-               <li>
-                  <a href="/find-ofsted-inspection-report">Find an Ofsted inspection report</a>
-               </li>
-               <li>
-                  <a href="/government/publications/common-inspection-framework-education-skills-and-early-years-from-september-2015">Common inspection framework: education, skills and early years from September 2015</a>
-               </li>
-               <li>
-                  <a href="/government/publications/early-years-inspection-handbook-from-september-2015">Early years inspection handbook from September 2015</a>
-               </li>
-               <li>
-                  <a href="/ofsted-inspection-childcare-provider">Being inspected as a childminder or childcare provider</a>
-               </li>
+             {% endfor %}
+
             </ol>
           </nav>
 
           <nav class="updated-list">
             <h2>Latest</h2>
             <ol>
-               <li>
-                  <a href="/government/publications/school-inspection-handbook-from-september-2015">School inspection handbook</a>
-                  <span>2 hours ago</span>
-               </li>
-               <li>
-                  <a href="/government/publications/inspecting-safeguarding-in-early-years-education-and-skills-from-september-2015">Inspecting safeguarding in early years, education and skills</a>
-                  <span>2 hours ago</span>
-               </li>
-               <li>
-                  <a href="/find-ofsted-inspection-report">Find an Ofsted inspection report</a>
-                  <span>4 hours ago</span>
-               </li>
-               <li>
-                  <a href="/government/publications/common-inspection-framework-education-skills-and-early-years-from-september-2015">Common inspection framework: education, skills and early years from September 2015</a>
-                  <span>8 hours ago</span>
-               </li>
+              {% for document in taxon.recentContent(5) %}
+                 <li>
+                   <a href="{{ document.base_path }}">{{ document.title }}</a>
+                   <span>{{ document.publicTimestamp | date("fromNow") }}</span>
+                 </li>
+               {% endfor %}
             </ol>
           </nav>
 

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "prompt": "^0.2.14",
     "readdir": "0.0.6",
     "serve-favicon": "2.3.0"
+  },
+  "devDependencies": {
+    "nunjucks-date-filter": "^0.1.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ var path = require('path'),
     express = require('express'),
     session = require('express-session'),
     nunjucks = require('express-nunjucks'),
+    dateFilter = require('nunjucks-date-filter'),
     routes = require(__dirname + '/app/routes.js'),
     favicon = require('serve-favicon'),
     app = express(),
@@ -48,6 +49,8 @@ nunjucks.ready(function(nj) {
   Object.keys(filters).forEach(function(filterName) {
     nj.addFilter(filterName, filters[filterName]);
   });
+
+  nj.addFilter('date', dateFilter);
 });
 
 // Middleware to serve static assets


### PR DESCRIPTION
Add methods to the Taxon class so we can easily extract sorted lists of documents in the taxon template. We're using momentjs to humanize the public timestamps.

@markhurrell 

![screen shot 2016-09-19 at 17 33 49](https://cloud.githubusercontent.com/assets/87579/18640406/f3eac7ae-7e8f-11e6-811c-0a2c080358e0.png)
