### PR TITLE
Add examples of each format to index page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -18,18 +18,21 @@
 
       <ul class="list list-bullet">
         <li><a href="/government/publications/early-years-foundation-stage-eyfs">Answer</a></li>
-        <li><a href="/guidance/key-stage-1-assessments">Detailed guidance</a></li>
-        <li><a href="/government/statistics/announcements/childcare-providers-and-inspections">Statistics anouncement</a></li>
+        <li><a href="/government/collections/phonics">Collection</a></li>
         <li><a href="/government/consultations/new-national-curriculum-primary-assessment-and-accountability">Consultation</a></li>
+        <li><a href="/government/organisations/department-for-education/about">Corporate Information Page</a></li>
+        <li><a href="/guidance/key-stage-1-assessments">Detailed guidance</a></li>
+        <li><a href="/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara">Manual</a></li>
         <li><a href="/government/news/a-third-of-children-reach-expected-level-in-pilot-of-phonics-check">News article</a></li>
-        <li><a href="/government/publications/early-years-newsletter-2015">Publication (correspondance)</a></li>
-        <li><a href="/government/statistics/official-statistics-early-years-and-childcare-registered-providers-inspections-and-outcomes">Publication (official statistics)</a></li>
-        <li><a href="/government/speeches/sarah-teather-to-the-family-and-parenting-institutes-conference">Speech</a></li>
+        <li><a href="/government/organisations/qualifications-and-curriculum-authority">Organisation</a></li>
+        <li><a href="/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents">Publication (promotional material)</a></li>
+        <li><a href="/government/publications/statement-on-national-curriculum-tests">Publication (correspondance)</a></li>
+        <li><a href="/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013">Publication (official statistics)</a></li>
+        <li><a href="/government/speeches/assessment-after-levels">Speech</a></li>
+        <li><a href="/government/statistics/announcements/childcare-providers-and-inspections">Statistics anouncement</a></li>
       </ul>
     </div>
   </div>
 </main>
 
 {% endblock %}
-
-


### PR DESCRIPTION
Not all of these are currently rendering correctly, and not all of them fall under the same part of the taxonomy (some are early years, some are KS1&2).

This is just to make it easy to work with the prototype, because some of the old links pointed to things that are not actually in the prototype anymore.

We may follow up on this by automatically generating links by format
https://trello.com/c/t85TTDmy/115-add-examples-of-formats-to-the-prototype-index