### PR TITLE
Display content pages for child taxons

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -160,14 +160,14 @@
     margin: 30px 0;
   }
 
-  
+
 
 }
 
 .statistics-announcement {
   .column-two-thirds {
     width: 100%;
-  }  
+  }
 }
 
 
@@ -177,7 +177,7 @@
    position: relative;
 }
 
-// fix breadcrumbs 
+// fix breadcrumbs
 
 .breadcrumbs {
    position: absolute;
@@ -188,7 +188,7 @@
       text-decoration: underline;
    }
 }
-#whitehall-wrapper {  
+#whitehall-wrapper {
    .breadcrumbs {
       a {
          color: black;
@@ -225,8 +225,8 @@
       }
    }
 }
-  
-#whitehall-wrapper {  
+
+#whitehall-wrapper {
   .headings-block {
      min-height: 45vh;
      .heading-with-extra {
@@ -246,7 +246,7 @@
    top: 5vh;
 }
 
-// align related nav to the content 
+// align related nav to the content
 
 .related-container {
    padding-top: 45vh;
@@ -280,9 +280,9 @@
 
 .related {
 /*
-   background: linear-gradient(to bottom, 
-      #ddd 0%, 
-      #ddd 19%, 
+   background: linear-gradient(to bottom,
+      #ddd 0%,
+      #ddd 19%,
       #fff 20%,
       #fff 100%);
    background-size: 100% 5px;
@@ -512,6 +512,8 @@
          padding: 30px;
          font-size: 19px;
          line-height: 25px;
+         float: left;
+         width: 100%;
       }
       ul {
          position: relative;
@@ -683,4 +685,3 @@
       }
    }
 }
-

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -36,18 +36,20 @@
           </nav>
 
           {% if taxon.atozChildren().length > 0 %}
+          {% for child_taxon in taxon.atozChildren() %}
           <nav role="navigation" aria-labelledby="parent-other" class="full-list">
-            <h2>Child taxon</h2>
+            <h2>{{ child_taxon.title }}</h2>
             <p>A short description of this topic to make it easier to understand</p>
             <ul>
-              {% for child_taxon in taxon.atozChildren() %}
+              {% for document in child_taxon.popularContent(5) %}
               <li>
-                <a href="{{ child_taxon.basePath }}">{{ child_taxon.title }}</a>
+                <a href="{{ document.basePath }}">{{ document.title }}</a>
               </li>
-            {% endfor %}
+              {% endfor %}
             </ul>
-            <a class="reveal" href="{{taxon.basePath}}/">See everything in Child taxon</a>
+            <a class="reveal" href="{{ child_taxon.basePath }}">See everything in {{ child_taxon.title }}</a>
           </nav>
+          {% endfor %}
           {% endif %}
 
           <nav role="navigation" aria-labelledby="parent-other" class="full-list">


### PR DESCRIPTION
This commit changes the taxonomy page template to display a block for each child taxon of the current taxon, and links to the first 5 content pages for each child taxon block.