### PR TITLE
Add education, training and skills to the index page

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,8 +12,15 @@
 
       <h1 class="heading-xlarge">GOV.UK Content Navigation prototype</h1>
 
+      <h2 class="heading-large">Topics</h2>
+      <ul class="list list-bullet">
+        <li><a href="/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills">Education, training and skills</a></li>
+      </ul>
+
+      <h2 class="heading-large">Content</h2>
+
       <p>
-        Examples of different content for the prototype
+        Examples of different content by format
       </p>
 
       <ul class="list list-bullet">


### PR DESCRIPTION
This is the taxonomy we're going to be testing in user research

It looks like this:

```
1 - Education, training and skills
  2 - Early years curriculum (0 to 5 years)
    3 - Phonics
      ↰ Early years curriculum (0 to 5 years)
      ↰ Primary curriculum, key stage 1 and key stage 2
  2 - School education (5 to 18 years)
    3 - School curriculum, assessment and performance
      4 - Primary curriculum, key stage 1 and key stage 2
        5 - Phonics
          ↰ Early years curriculum (0 to 5 years)
          ↰ Primary curriculum, key stage 1 and key stage 2
```