### PR TITLE
Correctly traverse parent taxons for breadcrumbs

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -100,7 +100,7 @@ var readFile = Promise.promisify(fs.readFile);
           }
         );
 
-        taxonParents = ancestor.links.parent;
+        taxonParents = ancestor.links.parent_taxons;
       }
 
       var breadcrumb = taxonAncestors.reverse();


### PR DESCRIPTION
This commit fixes a bug to correctly traverse parent taxons when compiling the breadcrumbs for display on a page.