### PR TITLE
Breadcrumbs on taxon pages

### DIFF
--- a/lib/js/breadcrumb_maker.js
+++ b/lib/js/breadcrumb_maker.js
@@ -1,0 +1,66 @@
+(function() {
+  "use strict";
+
+  class BreadcrumbMaker {
+    constructor(metadata) {
+      this.metadata = metadata;
+    }
+
+    getBreadcrumbForContent(page) {
+      // Pick the first taxon to generate a breadcrumb from
+      var taxonForPage = this.metadata.taxons_for_content[page];
+      if (taxonForPage === undefined) {
+        console.error("No metadata found for %s. The path should match a GOV.UK base path.", page);
+        return null;
+      }
+      var firstTaxon = taxonForPage[0];
+      return this.getBreadcrumbForParent(firstTaxon);
+    }
+
+    getBreadcrumbForTaxon(taxon) {
+      var taxonParent = this.metadata.ancestors_of_taxon[taxon];
+
+      if (taxonParent === null || taxonParent === []) {
+        return [{title: "Home", basePath: ""}];
+      } else {
+        return this.getBreadcrumbForParent(taxonParent[0].base_path);
+      }
+    }
+
+    getBreadcrumbForParent(firstTaxon) {
+      try {
+        var taxonAncestors = [
+          {
+            title: this.metadata.taxon_information[firstTaxon].title,
+            basePath: firstTaxon,
+          }
+        ];
+        var taxonParents = this.metadata.ancestors_of_taxon[firstTaxon];
+
+        while (taxonParents && taxonParents.length > 0) {
+          // Pick the first parent to use in the breadcrumb
+          var ancestor = taxonParents[0];
+
+          taxonAncestors.push(
+            {
+              title: ancestor.title,
+              basePath: ancestor.base_path,
+            }
+          );
+
+          taxonParents = ancestor.links.parent_taxons;
+        }
+
+        var breadcrumb = taxonAncestors.reverse();
+        breadcrumb.unshift({title: "Home", basePath: ""});
+        return breadcrumb;
+      }
+      catch (e) {
+        console.log("Problem getting breadcrumb data for " + firstTaxon);
+      }
+    }
+  }
+
+  module.exports = BreadcrumbMaker;
+
+})();

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "readdir": "0.0.6",
     "serve-favicon": "2.3.0",
     "nunjucks-date-filter": "^0.1.1"
+  },
+  "devDependencies": {
+    "jasmine": "^2.5.2"
   }
 }

--- a/spec/lib/js/breadcrumb_maker_spec.js
+++ b/spec/lib/js/breadcrumb_maker_spec.js
@@ -1,0 +1,56 @@
+var BreadcrumbMaker = require('../../../lib/js/breadcrumb_maker.js');
+var json_data = require('../../../app/data/metadata_and_taxons.json');
+
+describe('#getBreadcrumbForTaxon', function() {
+  var maker = new BreadcrumbMaker(json_data);
+
+  it('should return "Home" for a top-level taxon', function() {
+    var taxon = "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills";
+    expect(maker.getBreadcrumbForTaxon(taxon)).toEqual([
+      {
+        "basePath": "",
+        "title": "Home",
+      }
+    ]);
+  });
+
+  it('should return a full breadcrumb trail for a bottom-level taxon', function() {
+    var taxon = "/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2";
+    expect(maker.getBreadcrumbForTaxon(taxon)).toEqual([
+      {
+        "basePath": "",
+        "title": "Home",
+      },
+      {
+        "basePath": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+        "title": "Education, training and skills",
+      },
+      {
+        "basePath": "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+        "title": "School education (5 to 18 years)",
+      },
+      {
+        "basePath": "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+        "title": "School curriculum, assessment and performance",
+      }
+    ]);
+  });
+
+  it('should return a full breadcrumb trail using the first parent for a multi-parent bottom-level taxon', function() {
+    var taxon = "/alpha-taxonomy/phonics";
+    expect(maker.getBreadcrumbForTaxon(taxon)).toEqual([
+      {
+        "basePath": "",
+        "title": "Home",
+      },
+      {
+        "basePath": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+        "title": "Education, training and skills",
+      },
+      {
+        "basePath": "/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
+        "title": "Early years curriculum (0 to 5 years)",
+      }
+    ]);
+  });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
* Re-architect the breadcrumb functionality into a separate class to make it testable in isolation, and also show breadcrumbs on taxon pages.
* Add Jasmine tests for breadcrumb functionality.