### PR TITLE
Don’t display navigation elements for HTML publications

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -45,17 +45,20 @@ var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 
     var globPage = glob(directory + "/**/" + basename + ".html");
 
-    globPage.then(function (file){
+    globPage.then(function (file) {
       var filePath = file[0];
       return filePath;
     }).then(function(filePath) {
       readFile(filePath).then(function(data) {
         content = data.toString();
-        var breadcrumb = breadcrumbMaker.getBreadcrumbForContent(url);
-        var taxons = getTaxons(url);
-
-        console.log("Breadcrumb", breadcrumb);
         var whitehall = filePath.match(/whitehall/);
+        var html_publication = content.match(/html-publications-show/);
+
+        if (!html_publication) {
+          // Skip breadcrumbs and taxons for HTML publications since they have a unique format
+          var breadcrumb = breadcrumbMaker.getBreadcrumbForContent(url);
+          var taxons = getTaxons(url);
+        }
 
         res.render('content', { content: content, breadcrumb: breadcrumb, taxons: taxons, whitehall: whitehall, homepage_url: '/'});
       },

--- a/app/views/content.html
+++ b/app/views/content.html
@@ -4,12 +4,14 @@
 {% block content %}
 
   <div id="{% if whitehall %}whitehall-{% endif %}wrapper">
-    {% block breadcrumb %}
-      {% include '_breadcrumb.html' %}
-    {% endblock %}
+    {% if not html_publication %}
+      {% block breadcrumb %}
+        {% include '_breadcrumb.html' %}
+      {% endblock %}
+    {% endif %}
     <div class="grid-row">
       {{ content | safe }}
-      {% if taxons %}
+      {% if taxons and not html_publication %}
       {% include '_side_navigation.html' %}
       {% endif %}
     </div>


### PR DESCRIPTION
HTML publications currently have a unique template and do not have navigation elements since they are not in the publishing API. This commit detects an HTML publication page and removes all navigation elements from the template when displaying it.

Trello: https://trello.com/c/wYekO65n/132-render-html-publications-without-navigation-components-in-the-prototype

Before:

![screen shot 2016-09-26 at 13 24 26](https://cloud.githubusercontent.com/assets/444232/18834236/b005acd6-83ec-11e6-8978-82c935a51b2c.png)

After:

![screen shot 2016-09-26 at 13 24 08](https://cloud.githubusercontent.com/assets/444232/18834243/b60dffca-83ec-11e6-9b70-edb39a309273.png)
