### PR TITLE
Add a nicer 404 error page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -60,7 +60,7 @@ var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
         res.render('content', { content: content, breadcrumb: breadcrumb, taxons: taxons, whitehall: whitehall, homepage_url: '/'});
       },
       function (e) {
-        res.render('content', {content: 'Page not found', homepage_url: '/'});
+        res.status(404).render('404');
       });
     });
   });

--- a/app/views/404.html
+++ b/app/views/404.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+
+
+{% block content %}
+
+<main id="content" role="main" class="group">
+  <header class="page-header group">
+    <div>
+      <h1>Page not found</h1>
+    </div>
+  </header>
+  <div class="article-container">
+    <article role="article" class="group">
+      <div class="inner">
+        <p>If you entered a web address please check it was correct.</p>
+        <p>You can also <a href="/">browse from the homepage</a> to find the information you need.</p>
+      </div>
+    </article>
+  </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
This commit adds a nicer 404 error page, taken from the main GOV.UK site with small tweaks to align it with the prototype. It also sends an HTTP 404 status code with the page, for consistency and also to make it easier to spot errors when spidering the site.

NOTE: The actual 404 page needs some template work to make it look a little less crazy with all that whitespace.

Trello: https://trello.com/c/5GrNFWud/136-put-in-a-nice-404-page

Before:

![screen shot 2016-09-26 at 13 42 07](https://cloud.githubusercontent.com/assets/444232/18834713/66d725be-83ef-11e6-8cdb-92708d033a9a.png)

After:

![screen shot 2016-09-26 at 13 41 44](https://cloud.githubusercontent.com/assets/444232/18834717/6b3bb566-83ef-11e6-81d2-896b87670273.png)
