### PR TITLE
Ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/*
 .tmuxp.*
 link-checker-crawled-pages.pstore
 npm-debug.log
+venv


### PR DESCRIPTION
Python virtual environments are created in a `venv` folder which should not be committed to the repository, so the commit adds the folder to `.gitignore`.