### PR TITLE
Fix broken homepage links

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block page_title %}
-  GOV.UK prototype kit
+  GOV.UK Content Navigation prototype
 {% endblock %}
 
 {% block content %}
@@ -19,16 +19,14 @@
 
       <h2 class="heading-large">Content</h2>
 
-      <p>
-        Examples of different content by format
-      </p>
+      <p>Examples of different content by format</p>
 
       <ul class="list list-bullet">
-        <li><a href="/government/publications/early-years-foundation-stage-eyfs">Answer</a></li>
         <li><a href="/government/collections/phonics">Collection</a></li>
         <li><a href="/government/consultations/new-national-curriculum-primary-assessment-and-accountability">Consultation</a></li>
         <li><a href="/government/organisations/department-for-education/about">Corporate Information Page</a></li>
         <li><a href="/guidance/key-stage-1-assessments">Detailed guidance</a></li>
+        <li><a href="/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">HTML publication</a></li>
         <li><a href="/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara">Manual</a></li>
         <li><a href="/government/news/a-third-of-children-reach-expected-level-in-pilot-of-phonics-check">News article</a></li>
         <li><a href="/government/organisations/qualifications-and-curriculum-authority">Organisation</a></li>
@@ -36,7 +34,7 @@
         <li><a href="/government/publications/statement-on-national-curriculum-tests">Publication (correspondance)</a></li>
         <li><a href="/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013">Publication (official statistics)</a></li>
         <li><a href="/government/speeches/assessment-after-levels">Speech</a></li>
-        <li><a href="/government/statistics/announcements/childcare-providers-and-inspections">Statistics anouncement</a></li>
+        <li><a href="/government/statistics/announcements/eyfsp-attainment-by-pupil-characteristics-england-2015">Statistics anouncement</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This commit fixes some broken links on the prototype homepage where we no longer have certain pages available, and replaces them with new pages as far as possible.