### PR TITLE
Reformat taxon pages

### DIFF
--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -1,0 +1,56 @@
+(function() {
+  "use strict";
+
+  class ContentItem {
+    constructor(title, basePath, format, publicTimestamp) {
+      this.title = title;
+      this.basePath = basePath;
+      this.format = format;
+      this.publicTimestamp = publicTimestamp;
+    }
+
+    getHeading() {
+      switch (this.format) {
+        case 'news_article':
+        case 'speech':
+          return {
+            display_name: 'News and events',
+            id: 'news-and-events'
+          };
+          break;
+        case 'answer':
+        case 'detailed_guidance':
+        case 'manual':
+          return {
+            display_name: 'Other guidance',
+            id: 'other-guidance'
+          };
+          break;
+        case 'corporate_information_page':
+        case 'organisation':
+          return {
+            display_name: 'Corporate information',
+            id: 'corporate-information'
+          };
+          break;
+        case 'statistics_announcement':
+          return {
+            display_name: 'Data and statistics',
+            id: 'data-and-statistics'
+          };
+          break;
+        case 'consultation':
+          return {
+            display_name: 'Consultations and notices',
+            id: 'consultations-and-notices'
+          };
+          break;
+        default:
+          return null;
+      }
+    }
+  }
+
+  module.exports = ContentItem;
+
+})();

--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -1,0 +1,113 @@
+/*
+  Object to describe the structure of a taxon
+  (its child taxons and the documents tagged to it)
+*/
+(function() {
+  "use strict";
+
+  class Taxon {
+    constructor(title, basePath, description) {
+      this.title = title;
+      this.basePath = basePath;
+      this.description = description;
+      this.content = [];
+      this.children = [];
+    }
+
+    isOrganisation(basePath) {
+      return basePath.includes("/organisations/");
+    }
+
+    addContent(content) {
+      /*
+      Currently we're tagging organisation home pages and about pages
+      ("corporate information pages") to the taxonomy.
+
+      We're not sure if this is the right thing to do because these pages are
+      about the organisation themselves, not about the topic, even though
+      the organisation may be relevant to the topic. For now, just ignore these
+      tags, and don't mix these pages in with the rest of the content.
+      This is a workaround until we change how the content is tagged.
+      */
+      if (!this.isOrganisation(content.basePath)) {
+        this.content.push(content);
+      }
+    }
+
+    addChild(taxon) {
+      this.children.push(taxon);
+    }
+
+    popularContent(maxDocuments) {
+      return this.content.slice(0, maxDocuments);
+    }
+
+    atozContent(maxDocuments) {
+      var sorted = this.content.sort(function(a, b) {
+        if (a.title > b.title) {
+          return 1;
+        }
+
+        if (a.title < b.title) {
+          return -1;
+        }
+
+        return 0;
+      });
+
+      if (maxDocuments !== undefined) {
+        return sorted.slice(0, maxDocuments);
+      } else {
+        return sorted;
+      }
+    }
+
+    recentContent(maxDocuments) {
+      return this.content.sort(function(a, b) {
+        return b.publicTimestamp.getTime() - a.publicTimestamp.getTime();
+      }).slice(0, maxDocuments);
+    }
+
+    atozChildren() {
+      return this.children.sort(function(a, b) {
+        return a.title > b.title;
+      });
+    }
+
+    static fromMetadata(basePath, metadata) {
+      var taxonInformation = metadata.taxon_information[basePath];
+      if (taxonInformation === undefined) {
+        console.log("Missing taxon information for %s", basePath);
+        return null;
+      }
+
+      var taxon = new Taxon(taxonInformation.title, basePath, taxonInformation.description);
+      var contentItems = metadata.documents_in_taxon[basePath].results;
+      var childTaxons = metadata.children_of_taxon[basePath];
+
+      contentItems.forEach(function(contentItem) {
+        var publicTimestamp = contentItem.public_timestamp;
+
+        // Manual sections are missing a public timestamp: make one up
+        if (publicTimestamp === undefined) {
+            console.log("Made up timestamp for %s %s", contentItem.format, contentItem.link);
+            publicTimestamp = '2016-01-01T00:00:00+00:00';
+        }
+
+        taxon.addContent({title: contentItem.title, basePath: contentItem.link, format: contentItem.format, publicTimestamp: new Date(publicTimestamp)});
+      });
+
+      childTaxons.forEach(function(childTaxonBasePath) {
+        var childTaxon = Taxon.fromMetadata(childTaxonBasePath, metadata);
+        if (childTaxon !== null) {
+          taxon.addChild(childTaxon);
+        }
+      });
+
+      return taxon;
+    }
+  }
+
+  module.exports = Taxon;
+
+})();

--- a/app/routes.js
+++ b/app/routes.js
@@ -9,8 +9,9 @@ var readFile = Promise.promisify(fs.readFile);
 var cheerio = require('cheerio');
 var moment = require('moment');
 var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
+var Taxon = require('./models/taxon.js');
 
-(function(){
+(function() {
   "use strict";
 
   var metadata;
@@ -26,10 +27,10 @@ var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 
   router.get('/alpha-taxonomy/:taxons', function (req, res) {
     var taxonName = req.params.taxons;
-    console.log("Taxon page for: %s", taxonName);
     var url = "/alpha-taxonomy/" + taxonName;
-    var taxon = Taxon.fromMetadata(url);
+    var taxon = Taxon.fromMetadata(url, metadata);
     var breadcrumb = breadcrumbMaker.getBreadcrumbForTaxon([url]);
+    console.log("Taxon page for: %s", taxonName);
     res.render('taxonomy', {taxon: taxon, homepage_url: '/', breadcrumb: breadcrumb});
   });
 
@@ -100,121 +101,12 @@ var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
   }
 
   function getTaxons(url) {
-    try
-    {
+    try {
       return metadata.taxons_for_content[url].map(function(taxonBasePath) {
-        return Taxon.fromMetadata(taxonBasePath);
+        return Taxon.fromMetadata(taxonBasePath, metadata);
       });
-    }
-    catch(e){
+    } catch(e) {
       console.log("Problem getting taxons for sidebar");
-    }
-  }
-
-  /*
-    Object to describe the structure of a taxon
-    (its child taxons and the documents tagged to it)
-  */
-  class Taxon {
-    constructor(title, basePath, description) {
-      this.title = title;
-      this.basePath = basePath;
-      this.description = description;
-      this.content = [];
-      this.children = [];
-    }
-
-    isOrganisation(basePath) {
-      return basePath.includes("/organisations/");
-    }
-
-    addContent(content) {
-      /*
-      Currently we're tagging organisation home pages and about pages
-      ("corporate information pages") to the taxonomy.
-
-      We're not sure if this is the right thing to do because these pages are
-      about the organisation themselves, not about the topic, even though
-      the organisation may be relevant to the topic. For now, just ignore these
-      tags, and don't mix these pages in with the rest of the content.
-      This is a workaround until we change how the content is tagged.
-      */
-      if (!this.isOrganisation(content.basePath)) {
-        this.content.push(content);
-      }
-    }
-
-    addChild(taxon) {
-      this.children.push(taxon);
-    }
-
-    popularContent(maxDocuments) {
-      return this.content.slice(0, maxDocuments);
-    }
-
-    atozContent(maxDocuments) {
-      var sorted = this.content.sort(function(a, b) {
-        if (a.title > b.title) {
-          return 1;
-        }
-
-        if (a.title < b.title) {
-          return -1;
-        }
-
-        return 0;
-      });
-
-      if (maxDocuments !== undefined) {
-        return sorted.slice(0, maxDocuments);
-      } else {
-        return sorted;
-      }
-    }
-
-    recentContent(maxDocuments) {
-      return this.content.sort(function(a, b) {
-        return b.publicTimestamp.getTime() - a.publicTimestamp.getTime();
-      }).slice(0, maxDocuments);
-    }
-
-    atozChildren() {
-      return this.children.sort(function(a, b) {
-        return a.title > b.title;
-      });
-    }
-
-    static fromMetadata(basePath) {
-      var taxonInformation = metadata.taxon_information[basePath];
-      if (taxonInformation === undefined) {
-        console.log("Missing taxon information for %s", basePath);
-        return null;
-      }
-
-      var taxon = new Taxon(taxonInformation.title, basePath, taxonInformation.description);
-      var contentItems = metadata.documents_in_taxon[basePath].results;
-      var childTaxons = metadata.children_of_taxon[basePath];
-
-      contentItems.forEach(function(contentItem) {
-        var publicTimestamp = contentItem.public_timestamp;
-
-        // Manual sections are missing a public timestamp: make one up
-        if (publicTimestamp === undefined) {
-            console.log("Made up timestamp for %s %s", contentItem.format, contentItem.link);
-            publicTimestamp = '2016-01-01T00:00:00+00:00';
-        }
-
-        taxon.addContent({title: contentItem.title, basePath: contentItem.link, format: contentItem.format, publicTimestamp: new Date(publicTimestamp)});
-      });
-
-      childTaxons.forEach(function(childTaxonBasePath) {
-        var childTaxon = Taxon.fromMetadata(childTaxonBasePath);
-        if (childTaxon !== null) {
-          taxon.addChild(childTaxon);
-        }
-      });
-
-      return taxon;
     }
   }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -31,6 +31,7 @@ var Taxon = require('./models/taxon.js');
     var taxon = Taxon.fromMetadata(url, metadata);
     var breadcrumb = breadcrumbMaker.getBreadcrumbForTaxon([url]);
     console.log("Taxon page for: %s", taxonName);
+    taxon = taxon.filterByHeading("other-guidance");
     res.render('taxonomy', {taxon: taxon, homepage_url: '/', breadcrumb: breadcrumb});
   });
 


### PR DESCRIPTION
* Splits out the Taxon model into a separate file for cleaner code.
* Allows taxon contents to be filtered by “type”. At the moment, this is synonymous with the `format` field from rummager.