### PR TITLE
Split full list of links on taxon page by type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # gem "rails"
 gem 'gds-api-adapters', '~> 36.0'
 gem 'rake', '~> 11.2', '>= 11.2.2'
+gem 'oga', '~> 2.7'
 gem 'govuk-lint'
 gem 'rspec', '~> 3.4'
 gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     PriorityQueue (0.1.2)
+    ansi (1.5.0)
     ast (2.3.0)
-    byebug (9.0.5)
+    byebug (9.0.6)
     coderay (1.1.1)
     diff-lcs (1.2.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
-    gds-api-adapters (36.0.0)
+    gds-api-adapters (36.4.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -18,7 +19,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     link_header (0.0.8)
     lrucache (0.1.4)
@@ -29,7 +30,10 @@ GEM
     mime-types-data (3.2016.0521)
     netrc (0.11.0)
     null_logger (0.0.1)
-    parser (2.3.1.2)
+    oga (2.7)
+      ast
+      ruby-ll (~> 2.1)
+    parser (2.3.1.4)
       ast (~> 2.2)
     plek (1.12.0)
     powerpack (0.1.1)
@@ -44,7 +48,7 @@ GEM
     rack-cache (1.6.1)
       rack (>= 0.4)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -68,16 +72,19 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-ll (2.1.2)
+      ansi
+      ast
     ruby-progressbar (1.8.1)
     sass (3.4.22)
-    scss_lint (0.49.0)
+    scss_lint (0.50.2)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
     slop (3.6.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.1)
 
 PLATFORMS
   ruby
@@ -85,6 +92,7 @@ PLATFORMS
 DEPENDENCIES
   gds-api-adapters (~> 36.0)
   govuk-lint
+  oga (~> 2.7)
   pry-byebug
   rake (~> 11.2, >= 11.2.2)
   rspec (~> 3.4)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,14 +5,14 @@ module.exports = function(grunt){
     sass: {
       dev: {
         options: {
-          style: "expanded",
-          sourcemap: true,
           includePaths: [
             'govuk_modules/govuk_template/assets/stylesheets',
             'govuk_modules/govuk_frontend_toolkit/stylesheets',
             'govuk_modules/govuk-elements-sass/'
           ],
-          outputStyle: 'expanded'
+          outputStyle: 'expanded',
+          sourceComments: 'true',
+          sourceMap: true
         },
         files: [{
           expand: true,

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -594,7 +594,10 @@
          padding-bottom: 10px;
       }
       h3 {
-        @include heading-27;
+        @include bold-24;
+
+        padding-top: 20px;
+        padding-bottom: 10px
       }
       p {
          width: 50%;

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -524,7 +524,7 @@
          }
       }
    }
-   .full-list {
+   .child-taxon-list {
       clear: both;
       padding-top: 60px;
       h2 {
@@ -554,6 +554,64 @@
          margin-left: -100%;
          left: 100%;
          width: 100%;
+         list-style: none;
+      }
+      li {
+         position: relative;
+         font-size: 19px;
+         line-height: 25px;
+         padding-left: 30px;
+         &:before {
+            content: "•";
+            position: relative;
+            float: left;
+            width: 25px;
+            margin-left: -25px;
+         }
+         a {
+            text-decoration: none;
+            font-weight: bold;
+            &:hover {
+               text-decoration: underline;
+            }
+         }
+      }
+   }
+   .full-list {
+      clear: both;
+      padding-top: 60px;
+      div {
+        position: relative;
+        float: left;
+        margin: 0;
+        margin-left: -100%;
+        left: 100%;
+        width: 100%;
+      }
+      h2 {
+         width: 50%;
+         float: left;
+         padding-bottom: 10px;
+      }
+      h3 {
+        @include heading-27;
+      }
+      p {
+         width: 50%;
+         float: left;
+         clear: left;
+         margin: 0;
+      }
+      .reveal {
+         margin-left: 50%;
+         position: relative;
+         left: 30px;
+         float: left;
+         font-size: 16px;
+         line-height: 20px;
+         padding-top: 5px;
+      }
+      ul {
          list-style: none;
       }
       li {

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -4,7 +4,7 @@
 
 // Take a look at in app/assets/sass/patterns/ to see which files are imported.
 @import 'patterns/check-your-answers';
-@import 'patterns/unbranded';
+// @import 'patterns/unbranded';
 
 // Related items
 // (These styles will be moved to GOV.UK elements, duplicating here for now.)

--- a/app/data/metadata_and_taxons.json
+++ b/app/data/metadata_and_taxons.json
@@ -1565,16 +1565,16 @@
     "/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5": [
       {
         "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
-        "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
         "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
         "description": "Early years learning, school education, further and higher education, skills and vocational training.",
         "document_type": "taxon",
-        "locale": "en",
         "public_updated_at": "2016-09-23T09:19:23Z",
         "schema_name": "taxon",
         "title": "Education, training and skills",
-        "web_url": "https://www.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+        "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+        "locale": "en",
+        "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+        "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
         "links": {
         }
       }
@@ -1582,44 +1582,44 @@
     "/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2": [
       {
         "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
-        "base_path": "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
         "content_id": "ff9bcd45-4dac-4e9d-a78b-0e790e24a47c",
-        "description": "",
+        "description": "Primary and secondary curricula, teaching and assessment, non-academic development.",
         "document_type": "taxon",
-        "locale": "en",
-        "public_updated_at": "2016-09-15T09:29:27Z",
+        "public_updated_at": "2016-09-23T09:21:49Z",
         "schema_name": "taxon",
         "title": "School curriculum, assessment and performance",
-        "web_url": "https://www.gov.uk/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+        "base_path": "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+        "locale": "en",
+        "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+        "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
         "links": {
           "parent_taxons": [
             {
               "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
-              "base_path": "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
               "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
-              "description": "",
+              "description": "Going to school, running a school, teaching and learning, alternatives to school.",
               "document_type": "taxon",
-              "locale": "en",
-              "public_updated_at": "2016-09-15T09:29:44Z",
+              "public_updated_at": "2016-09-23T09:22:02Z",
               "schema_name": "taxon",
               "title": "School education (5 to 18 years)",
-              "web_url": "https://www.gov.uk/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+              "base_path": "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+              "locale": "en",
+              "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+              "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
               "links": {
                 "parent_taxons": [
                   {
                     "analytics_identifier": null,
-                    "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
-                    "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
                     "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
                     "description": "Early years learning, school education, further and higher education, skills and vocational training.",
                     "document_type": "taxon",
-                    "locale": "en",
                     "public_updated_at": "2016-09-23T09:19:23Z",
                     "schema_name": "taxon",
                     "title": "Education, training and skills",
-                    "web_url": "https://www.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                    "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                    "locale": "en",
+                    "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                    "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
                     "links": {
                     }
                   }
@@ -1684,58 +1684,58 @@
     "/alpha-taxonomy/phonics": [
       {
         "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
-        "base_path": "/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
         "content_id": "904cfd73-2707-47b8-8754-5765ec5a5b68",
-        "description": "",
+        "description": "Teaching and assessing the primary curriculum, primary school performance data, ",
         "document_type": "taxon",
-        "locale": "en",
-        "public_updated_at": "2016-09-15T09:28:35Z",
+        "public_updated_at": "2016-09-23T09:21:00Z",
         "schema_name": "taxon",
         "title": "Primary curriculum, key stage 1 and key stage 2",
-        "web_url": "https://www.gov.uk/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
+        "base_path": "/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
+        "locale": "en",
+        "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
+        "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2",
         "links": {
           "parent_taxons": [
             {
               "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
-              "base_path": "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
               "content_id": "ff9bcd45-4dac-4e9d-a78b-0e790e24a47c",
-              "description": "",
+              "description": "Primary and secondary curricula, teaching and assessment, non-academic development.",
               "document_type": "taxon",
-              "locale": "en",
-              "public_updated_at": "2016-09-15T09:29:27Z",
+              "public_updated_at": "2016-09-23T09:21:49Z",
               "schema_name": "taxon",
               "title": "School curriculum, assessment and performance",
-              "web_url": "https://www.gov.uk/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+              "base_path": "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+              "locale": "en",
+              "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
+              "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance",
               "links": {
                 "parent_taxons": [
                   {
                     "analytics_identifier": null,
-                    "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
-                    "base_path": "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
                     "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
-                    "description": "",
+                    "description": "Going to school, running a school, teaching and learning, alternatives to school.",
                     "document_type": "taxon",
-                    "locale": "en",
-                    "public_updated_at": "2016-09-15T09:29:44Z",
+                    "public_updated_at": "2016-09-23T09:22:02Z",
                     "schema_name": "taxon",
                     "title": "School education (5 to 18 years)",
-                    "web_url": "https://www.gov.uk/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+                    "base_path": "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+                    "locale": "en",
+                    "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
+                    "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18",
                     "links": {
                       "parent_taxons": [
                         {
                           "analytics_identifier": null,
-                          "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
-                          "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
                           "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
                           "description": "Early years learning, school education, further and higher education, skills and vocational training.",
                           "document_type": "taxon",
-                          "locale": "en",
                           "public_updated_at": "2016-09-23T09:19:23Z",
                           "schema_name": "taxon",
                           "title": "Education, training and skills",
-                          "web_url": "https://www.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                          "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                          "locale": "en",
+                          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+                          "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
                           "links": {
                           }
                         }
@@ -1750,30 +1750,30 @@
       },
       {
         "analytics_identifier": null,
-        "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
-        "base_path": "/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
         "content_id": "07299ca5-bc4d-48dd-a3f1-edd3b170bb4a",
         "description": "Pre-school education, Early Years Foundation Stage, phonics.",
         "document_type": "taxon",
-        "locale": "en",
         "public_updated_at": "2016-09-23T09:20:19Z",
         "schema_name": "taxon",
         "title": "Early years curriculum (0 to 5 years)",
-        "web_url": "https://www.gov.uk/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
+        "base_path": "/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
+        "locale": "en",
+        "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
+        "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/05aefd16-99ac-4d76-87c4-54c4123b3012-early-years-curriculum-0-to-5",
         "links": {
           "parent_taxons": [
             {
               "analytics_identifier": null,
-              "api_url": "https://www.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
-              "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
               "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
               "description": "Early years learning, school education, further and higher education, skills and vocational training.",
               "document_type": "taxon",
-              "locale": "en",
               "public_updated_at": "2016-09-23T09:19:23Z",
               "schema_name": "taxon",
               "title": "Education, training and skills",
-              "web_url": "https://www.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+              "base_path": "/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+              "locale": "en",
+              "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
+              "web_url": "https://www-origin.staging.publishing.service.gov.uk/alpha-taxonomy/2b5d0d82-a099-41fc-b40b-a71f2404dcde-education-training-and-skills",
               "links": {
               }
             }
@@ -1817,7 +1817,7 @@
     "/alpha-taxonomy/6f6f5609-9075-4762-9d98-3d649a26348b-primary-curriculum-key-stage-1-and-key-stage-2": {
       "title": "Primary curriculum, key stage 1 and key stage 2",
       "content_id": "904cfd73-2707-47b8-8754-5765ec5a5b68",
-      "description": "Teaching and assessing the primary curriculum, primary school performance data."
+      "description": "Teaching and assessing the primary curriculum, primary school performance data, "
     },
     "/alpha-taxonomy/b33a69cf-ff92-47d1-b995-44d89acda8db-curriculum-qualifications-and-school-performance": {
       "title": "School curriculum, assessment and performance",
@@ -1827,7 +1827,7 @@
     "/alpha-taxonomy/ca860c58-665d-491d-88ed-26bf2e76fe19-school-education-5-to-18": {
       "title": "School education (5 to 18 years)",
       "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
-      "description": "Going to school, running a school, teaching and learning, alternatives to school."
+      "description": ""
     },
     "/alpha-taxonomy/phonics": {
       "title": "Phonics",
@@ -1905,6 +1905,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Queen’s Birthday Honours 2014: education and children's services",
+          "description": "Queen’s Birthday Honours recognise the contribution of teachers, foster parents and carers.\r\n\r\n",
+          "link": "/government/news/queens-birthday-honours-2014-education-and-childrens-services",
+          "format": "news_article",
+          "public_timestamp": "2014-06-14T00:15:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/queens-birthday-honours-2014-education-and-childrens-services",
+          "document_type": "edition"
+        },
+        {
           "title": "New Year Honours list 2015: education and children’s services",
           "description": "The list of people working in education and children’s services who have received an honour.",
           "link": "/government/news/new-year-honours-list-2015-education-and-childrens-services",
@@ -1927,36 +1938,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Nicky Morgan discusses the future of education in England",
-          "description": "Nicky Morgan, Secretary of State for Education, speaks at the Sunday Times Festival of Education.",
-          "link": "/government/speeches/nicky-morgan-discusses-the-future-of-education-in-england",
+          "title": "Michael Gove: an education system which works for every child",
+          "description": "The Secretary of State for Education speaks to the British Chambers of Commerce about vocational education, literacy and numeracy.",
+          "link": "/government/speeches/michael-gove-an-education-system-which-works-for-every-child",
           "format": "speech",
-          "public_timestamp": "2015-06-18T09:11:00.000+01:00",
+          "public_timestamp": "2014-04-01T12:35:18.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/nicky-morgan-discusses-the-future-of-education-in-england",
-          "document_type": "edition"
-        },
-        {
-          "title": "Education Secretary Michael Gove's speech to Brighton College",
-          "description": "Michael Gove speaks at Brighton College about the government's initiatives to address the educational attainment gap.",
-          "link": "/government/speeches/education-secretary-michael-goves-speech-to-brighton-college",
-          "format": "speech",
-          "public_timestamp": "2012-05-10T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-brighton-college",
-          "document_type": "edition"
-        },
-        {
-          "title": "Queen’s Birthday Honours 2014: education and children's services",
-          "description": "Queen’s Birthday Honours recognise the contribution of teachers, foster parents and carers.\r\n\r\n",
-          "link": "/government/news/queens-birthday-honours-2014-education-and-childrens-services",
-          "format": "news_article",
-          "public_timestamp": "2014-06-14T00:15:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/queens-birthday-honours-2014-education-and-childrens-services",
+          "_id": "/government/speeches/michael-gove-an-education-system-which-works-for-every-child",
           "document_type": "edition"
         },
         {
@@ -1971,14 +1960,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove: an education system which works for every child",
-          "description": "The Secretary of State for Education speaks to the British Chambers of Commerce about vocational education, literacy and numeracy.",
-          "link": "/government/speeches/michael-gove-an-education-system-which-works-for-every-child",
-          "format": "speech",
-          "public_timestamp": "2014-04-01T12:35:18.000+01:00",
+          "title": "Setting research priorities in education and children’s services",
+          "description": "The Department for Education is asking the education and children’s sector to help set research priorities.",
+          "link": "/government/news/setting-research-priorities-in-education-and-childrens-services",
+          "format": "news_article",
+          "public_timestamp": "2014-03-13T09:39:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/michael-gove-an-education-system-which-works-for-every-child",
+          "_id": "/government/news/setting-research-priorities-in-education-and-childrens-services",
+          "document_type": "edition"
+        },
+        {
+          "title": "Nicky Morgan discusses the future of education in England",
+          "description": "Nicky Morgan, Secretary of State for Education, speaks at the Sunday Times Festival of Education.",
+          "link": "/government/speeches/nicky-morgan-discusses-the-future-of-education-in-england",
+          "format": "speech",
+          "public_timestamp": "2015-06-18T09:11:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/nicky-morgan-discusses-the-future-of-education-in-england",
           "document_type": "edition"
         },
         {
@@ -1993,25 +1993,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Education Secretary Michael Gove's speech to ASCL",
-          "description": "Michael Gove's speech on the future of education to the Association of School and College Leaders.",
-          "link": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "title": "Education Secretary Michael Gove's speech to Brighton College",
+          "description": "Michael Gove speaks at Brighton College about the government's initiatives to address the educational attainment gap.",
+          "link": "/government/speeches/education-secretary-michael-goves-speech-to-brighton-college",
           "format": "speech",
-          "public_timestamp": "2012-03-26T01:00:00.000+01:00",
+          "public_timestamp": "2012-05-10T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
-          "document_type": "edition"
-        },
-        {
-          "title": "Setting research priorities in education and children’s services",
-          "description": "The Department for Education is asking the education and children’s sector to help set research priorities.",
-          "link": "/government/news/setting-research-priorities-in-education-and-childrens-services",
-          "format": "news_article",
-          "public_timestamp": "2014-03-13T09:39:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/setting-research-priorities-in-education-and-childrens-services",
+          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-brighton-college",
           "document_type": "edition"
         },
         {
@@ -2026,47 +2015,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove at the National College annual conference",
-          "description": "The Education Secretary speaks about the department's new policies aimed at recruiting and training the next generation of teachers.",
-          "link": "/government/speeches/michael-gove-at-the-national-college-annual-conference",
+          "title": "Michael Gove to the Durand Academy",
+          "description": "The Secretary of State talks about the making of an 'educational underclass'.",
+          "link": "/government/speeches/michael-gove-to-the-durand-academy",
           "format": "speech",
-          "public_timestamp": "2012-06-14T01:00:00.000+01:00",
+          "public_timestamp": "2011-09-01T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/michael-gove-at-the-national-college-annual-conference",
-          "document_type": "edition"
-        },
-        {
-          "title": "Ofqual Report to Parliament",
-          "description": "Ofqual’s second Report to Parliament covers the period from 1 April 2011 to 31 December 2014. ",
-          "link": "/government/news/ofqual-report-to-parliament",
-          "format": "news_article",
-          "public_timestamp": "2015-02-12T11:33:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/ofqual-report-to-parliament",
-          "document_type": "edition"
-        },
-        {
-          "title": "Department for Education annual report and accounts: financial year 2010 to 2011",
-          "description": "Report showing the government’s output and planned expenditure for the financial year 2011 to 2012.",
-          "link": "/government/publications/department-for-education-annual-report-and-accounts-financial-year-2010-to-2011",
-          "format": "publication",
-          "public_timestamp": "2011-07-07T12:39:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/department-for-education-annual-report-and-accounts-financial-year-2010-to-2011",
-          "document_type": "edition"
-        },
-        {
-          "title": "Nick Clegg’s speech  on education and outstanding leaders",
-          "description": "The Deputy Prime Minister’s speech on education and a new programme to get outstanding leaders into the schools that need them the most.",
-          "link": "/government/speeches/nick-cleggs-speech-on-education-and-outstanding-leaders",
-          "format": "speech",
-          "public_timestamp": "2013-10-24T14:50:21.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/nick-cleggs-speech-on-education-and-outstanding-leaders",
+          "_id": "/government/speeches/michael-gove-to-the-durand-academy",
           "document_type": "edition"
         },
         {
@@ -2081,6 +2037,28 @@
           "document_type": "edition"
         },
         {
+          "title": "Education Secretary Michael Gove's speech to ASCL",
+          "description": "Michael Gove's speech on the future of education to the Association of School and College Leaders.",
+          "link": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "format": "speech",
+          "public_timestamp": "2012-03-26T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "document_type": "edition"
+        },
+        {
+          "title": "Michael Gove at the National College annual conference",
+          "description": "The Education Secretary speaks about the department's new policies aimed at recruiting and training the next generation of teachers.",
+          "link": "/government/speeches/michael-gove-at-the-national-college-annual-conference",
+          "format": "speech",
+          "public_timestamp": "2012-06-14T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/michael-gove-at-the-national-college-annual-conference",
+          "document_type": "edition"
+        },
+        {
           "title": "Nick Gibb to the Association of Teachers and Lecturers 2011 Conference",
           "description": "The Schools Minister addresses the Association of Teachers and Lecturers 2011 annual conference in Liverpool on government education policy.",
           "link": "/government/speeches/nick-gibb-to-the-association-of-teachers-and-lecturers-2011-conference",
@@ -2092,36 +2070,36 @@
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove to the National Conference of Directors of Children's and Adult Services",
-          "description": "The Education Secretary on the coalition plans for education, including how schools will be identified for the Academies programme.",
-          "link": "/government/speeches/michael-gove-to-the-national-conference-of-directors-of-childrens-and-adult-services",
-          "format": "speech",
-          "public_timestamp": "2011-02-09T00:00:00.000+00:00",
+          "title": "Ofqual Report to Parliament",
+          "description": "Ofqual’s second Report to Parliament covers the period from 1 April 2011 to 31 December 2014. ",
+          "link": "/government/news/ofqual-report-to-parliament",
+          "format": "news_article",
+          "public_timestamp": "2015-02-12T11:33:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/michael-gove-to-the-national-conference-of-directors-of-childrens-and-adult-services",
+          "_id": "/government/news/ofqual-report-to-parliament",
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove to the Durand Academy",
-          "description": "The Secretary of State talks about the making of an 'educational underclass'.",
-          "link": "/government/speeches/michael-gove-to-the-durand-academy",
+          "title": "Nick Clegg’s speech  on education and outstanding leaders",
+          "description": "The Deputy Prime Minister’s speech on education and a new programme to get outstanding leaders into the schools that need them the most.",
+          "link": "/government/speeches/nick-cleggs-speech-on-education-and-outstanding-leaders",
           "format": "speech",
-          "public_timestamp": "2011-09-01T01:00:00.000+01:00",
+          "public_timestamp": "2013-10-24T14:50:21.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/michael-gove-to-the-durand-academy",
+          "_id": "/government/speeches/nick-cleggs-speech-on-education-and-outstanding-leaders",
           "document_type": "edition"
         },
         {
-          "title": "Nick Gibb: the fruits of autonomy",
-          "description": "School Reform Minister Nick Gibb speaks to Reform about the changes that have led to more freedom in the education system.",
-          "link": "/government/speeches/nick-gibb-the-fruits-of-autonomy",
-          "format": "speech",
-          "public_timestamp": "2014-11-13T14:00:00.000+00:00",
+          "title": "Department for Education annual report and accounts: financial year 2010 to 2011",
+          "description": "Report showing the government’s output and planned expenditure for the financial year 2011 to 2012.",
+          "link": "/government/publications/department-for-education-annual-report-and-accounts-financial-year-2010-to-2011",
+          "format": "publication",
+          "public_timestamp": "2011-07-07T12:39:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/nick-gibb-the-fruits-of-autonomy",
+          "_id": "/government/publications/department-for-education-annual-report-and-accounts-financial-year-2010-to-2011",
           "document_type": "edition"
         },
         {
@@ -2147,6 +2125,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Nick Gibb: the fruits of autonomy",
+          "description": "School Reform Minister Nick Gibb speaks to Reform about the changes that have led to more freedom in the education system.",
+          "link": "/government/speeches/nick-gibb-the-fruits-of-autonomy",
+          "format": "speech",
+          "public_timestamp": "2014-11-13T14:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/nick-gibb-the-fruits-of-autonomy",
+          "document_type": "edition"
+        },
+        {
           "title": "Nick Gibb speaks at the Centre for Social Justice",
           "description": "The Schools Minister talks about the importance of creating a world class education system.",
           "link": "/government/speeches/nick-gibb-speaks-at-the-centre-for-social-justice",
@@ -2155,6 +2144,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/speeches/nick-gibb-speaks-at-the-centre-for-social-justice",
+          "document_type": "edition"
+        },
+        {
+          "title": "Michael Gove to the National Conference of Directors of Children's and Adult Services",
+          "description": "The Education Secretary on the coalition plans for education, including how schools will be identified for the Academies programme.",
+          "link": "/government/speeches/michael-gove-to-the-national-conference-of-directors-of-childrens-and-adult-services",
+          "format": "speech",
+          "public_timestamp": "2011-02-09T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/michael-gove-to-the-national-conference-of-directors-of-childrens-and-adult-services",
           "document_type": "edition"
         }
       ],
@@ -2213,6 +2213,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Paediatric first aid: EYFS statutory framework amendments",
+          "description": "We are seeking views on proposals for newly qualified level 2 or 3 early years staff to hold a paediatric first aid certificate.",
+          "link": "/government/consultations/paediatric-first-aid-eyfs-statutory-framework-amendments",
+          "format": "consultation",
+          "public_timestamp": "2016-07-01T09:32:53.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/consultations/paediatric-first-aid-eyfs-statutory-framework-amendments",
+          "document_type": "edition"
+        },
+        {
           "title": "2016 Early years foundation stage: assessment and reporting arrangements (ARA): Section 2: Early years foundation stage profile",
           "description": "An overview of the EYFS profile and information about completing the profile and exemptions from assessment",
           "link": "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-2-early-years-foundation-stage-profile",
@@ -2245,14 +2256,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Paediatric first aid: EYFS statutory framework amendments",
-          "description": "We are seeking views on proposals for newly qualified level 2 or 3 early years staff to hold a paediatric first aid certificate.",
-          "link": "/government/consultations/paediatric-first-aid-eyfs-statutory-framework-amendments",
-          "format": "consultation",
-          "public_timestamp": "2016-07-01T09:32:53.000+01:00",
+          "title": "Tickell review of the early years foundation stage",
+          "description": "A review into the impact of the early years foundation stage (EYFS) on children's learning and development, and  early years practitioners.",
+          "link": "/government/publications/the-early-years-foundations-for-life-health-and-learning-an-independent-report-on-the-early-years-foundation-stage-to-her-majestys-government",
+          "format": "publication",
+          "public_timestamp": "2011-03-30T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/consultations/paediatric-first-aid-eyfs-statutory-framework-amendments",
+          "_id": "/government/publications/the-early-years-foundations-for-life-health-and-learning-an-independent-report-on-the-early-years-foundation-stage-to-her-majestys-government",
           "document_type": "edition"
         },
         {
@@ -2278,15 +2289,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Tickell review of the early years foundation stage",
-          "description": "A review into the impact of the early years foundation stage (EYFS) on children's learning and development, and  early years practitioners.",
-          "link": "/government/publications/the-early-years-foundations-for-life-health-and-learning-an-independent-report-on-the-early-years-foundation-stage-to-her-majestys-government",
-          "format": "publication",
-          "public_timestamp": "2011-03-30T01:00:00.000+01:00",
-          "index": "government",
+          "title": "2016 Early years foundation stage: assessment and reporting arrangements (ARA): Section 1: Introduction",
+          "description": "About the EYFS ARA and how to use the new manuals format",
+          "link": "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "format": "manual_section",
+          "index": "mainstream",
           "es_score": null,
-          "_id": "/government/publications/the-early-years-foundations-for-life-health-and-learning-an-independent-report-on-the-early-years-foundation-stage-to-her-majestys-government",
-          "document_type": "edition"
+          "_id": "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "document_type": "manual_section"
         },
         {
           "title": "The importance of music: a national plan for music education",
@@ -2298,16 +2308,6 @@
           "es_score": null,
           "_id": "/government/publications/the-importance-of-music-a-national-plan-for-music-education",
           "document_type": "edition"
-        },
-        {
-          "title": "2016 Early years foundation stage: assessment and reporting arrangements (ARA): Section 1: Introduction",
-          "description": "About the EYFS ARA and how to use the new manuals format",
-          "link": "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction",
-          "document_type": "manual_section"
         },
         {
           "title": "2016 Early years foundation stage: assessment and reporting arrangements (ARA): Section 5: Legal requirements and responsibilities ",
@@ -2340,14 +2340,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Improving early years teaching: learning from others",
-          "description": "Ofsted good practice example showing how Broomhall Nursery School and Children’s Centre learns from others to enhance early years provision.",
-          "link": "/government/publications/collaborating-to-support-early-years-teaching-and-learning",
+          "title": "Early years foundation stage profile results: 2013 to 2014",
+          "description": "Early years foundation stage profile  (EYFSP) results in England, for the 2013 to 2014 academic year, at national and local authority level.",
+          "link": "/government/statistics/early-years-foundation-stage-profile-results-2013-to-2014",
           "format": "publication",
-          "public_timestamp": "2015-07-13T10:15:00.000+01:00",
+          "public_timestamp": "2014-10-16T09:30:14.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/collaborating-to-support-early-years-teaching-and-learning",
+          "_id": "/government/statistics/early-years-foundation-stage-profile-results-2013-to-2014",
           "document_type": "edition"
         },
         {
@@ -2361,36 +2361,14 @@
           "document_type": "manual_section"
         },
         {
-          "title": "Children’s wellbeing, learning and development: parent/carer partnerships",
-          "description": "Ofsted good practice example showing how a childminder develops partnerships to support wellbeing, learning and development.",
-          "link": "/government/publications/partnerships-between-parents-and-carers",
+          "title": "Improving early years teaching: learning from others",
+          "description": "Ofsted good practice example showing how Broomhall Nursery School and Children’s Centre learns from others to enhance early years provision.",
+          "link": "/government/publications/collaborating-to-support-early-years-teaching-and-learning",
           "format": "publication",
-          "public_timestamp": "2013-07-03T01:00:00.000+01:00",
+          "public_timestamp": "2015-07-13T10:15:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/partnerships-between-parents-and-carers",
-          "document_type": "edition"
-        },
-        {
-          "title": "Early years foundation stage profile results: 2013 to 2014",
-          "description": "Early years foundation stage profile  (EYFSP) results in England, for the 2013 to 2014 academic year, at national and local authority level.",
-          "link": "/government/statistics/early-years-foundation-stage-profile-results-2013-to-2014",
-          "format": "publication",
-          "public_timestamp": "2014-10-16T09:30:14.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/statistics/early-years-foundation-stage-profile-results-2013-to-2014",
-          "document_type": "edition"
-        },
-        {
-          "title": "Improving boys’ literacy skills",
-          "description": "Ofsted good practice example showing how Greenfields Children’s Centre uses assessment to close gaps, especially in literacy.",
-          "link": "/government/publications/improving-boys-literacy-skills",
-          "format": "publication",
-          "public_timestamp": "2015-07-13T10:15:02.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/improving-boys-literacy-skills",
+          "_id": "/government/publications/collaborating-to-support-early-years-teaching-and-learning",
           "document_type": "edition"
         },
         {
@@ -2405,17 +2383,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Removing barriers to literacy",
-          "description": "Ofsted survey report illustrating effective approaches in literacy that might help others to improve their practice.",
-          "link": "/government/publications/removing-barriers-to-literacy",
-          "format": "publication",
-          "public_timestamp": "2011-01-21T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/removing-barriers-to-literacy",
-          "document_type": "edition"
-        },
-        {
           "title": "Learning together through play in the early years",
           "description": "This good practice example shows how St John Vianney Primary School Childcare involves parents in their children's learning.",
           "link": "/government/publications/learning-together-through-play-in-the-early-years",
@@ -2427,25 +2394,36 @@
           "document_type": "edition"
         },
         {
-          "title": "Early years foundation stage profile return: how to submit data",
-          "description": "How local authorities should submit data from early years providers to complete the early years foundation stage profile (EYFSP) return.",
-          "link": "/guidance/early-years-foundation-stage-profile",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-05-20T11:45:42.000+01:00",
-          "index": "detailed",
+          "title": "Improving boys’ literacy skills",
+          "description": "Ofsted good practice example showing how Greenfields Children’s Centre uses assessment to close gaps, especially in literacy.",
+          "link": "/government/publications/improving-boys-literacy-skills",
+          "format": "publication",
+          "public_timestamp": "2015-07-13T10:15:02.000+01:00",
+          "index": "government",
           "es_score": null,
-          "_id": "/guidance/early-years-foundation-stage-profile",
+          "_id": "/government/publications/improving-boys-literacy-skills",
           "document_type": "edition"
         },
         {
-          "title": "EYFSP attainment by pupil characteristics: 2013 to 2014",
-          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2013 to 2014.",
-          "link": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013-to-2014",
+          "title": "Children’s wellbeing, learning and development: parent/carer partnerships",
+          "description": "Ofsted good practice example showing how a childminder develops partnerships to support wellbeing, learning and development.",
+          "link": "/government/publications/partnerships-between-parents-and-carers",
           "format": "publication",
-          "public_timestamp": "2014-11-20T09:30:00.000+00:00",
+          "public_timestamp": "2013-07-03T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013-to-2014",
+          "_id": "/government/publications/partnerships-between-parents-and-carers",
+          "document_type": "edition"
+        },
+        {
+          "title": "Removing barriers to literacy",
+          "description": "Ofsted survey report illustrating effective approaches in literacy that might help others to improve their practice.",
+          "link": "/government/publications/removing-barriers-to-literacy",
+          "format": "publication",
+          "public_timestamp": "2011-01-21T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/removing-barriers-to-literacy",
           "document_type": "edition"
         },
         {
@@ -2460,6 +2438,28 @@
           "document_type": "edition"
         },
         {
+          "title": "EYFSP attainment by pupil characteristics: 2013 to 2014",
+          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2013 to 2014.",
+          "link": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013-to-2014",
+          "format": "publication",
+          "public_timestamp": "2014-11-20T09:30:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013-to-2014",
+          "document_type": "edition"
+        },
+        {
+          "title": "Early years foundation stage profile return: how to submit data",
+          "description": "How local authorities should submit data from early years providers to complete the early years foundation stage profile (EYFSP) return.",
+          "link": "/guidance/early-years-foundation-stage-profile",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-05-20T11:45:42.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/early-years-foundation-stage-profile",
+          "document_type": "edition"
+        },
+        {
           "title": "Early years foundation stage to be radically slimmed down",
           "description": "Dame Clare Tickell recommends streamlining the EYFS to make it more focused on making sure children start school ready to learn.",
           "link": "/government/news/early-years-foundation-stage-to-be-radically-slimmed-down",
@@ -2468,39 +2468,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/news/early-years-foundation-stage-to-be-radically-slimmed-down",
-          "document_type": "edition"
-        },
-        {
-          "title": "Integrated review at age 2: implementation study",
-          "description": "Exploring the effect of integrating the early years foundation stage (EYFS) progress check with the healthy child programme (HCP) check.",
-          "link": "/government/publications/integrated-review-at-age-2-implementation-study",
-          "format": "publication",
-          "public_timestamp": "2014-11-21T09:30:04.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/integrated-review-at-age-2-implementation-study",
-          "document_type": "edition"
-        },
-        {
-          "title": "Results of the early years foundation stage profile pilot",
-          "description": "This report describes the results of the pilot to support the introduction of the new profile.",
-          "link": "/government/publications/results-of-the-early-years-foundation-stage-profile-pilot",
-          "format": "publication",
-          "public_timestamp": "2013-03-27T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/results-of-the-early-years-foundation-stage-profile-pilot",
-          "document_type": "edition"
-        },
-        {
-          "title": "Early years foundation stage profile results: 2012 to 2013",
-          "description": "Early years foundation stage profile (EYFSP) results in England, for the 2012 to 2013 academic year, at national and local authority level.",
-          "link": "/government/statistics/early-years-foundation-stage-profile-results-2012-to-2013",
-          "format": "publication",
-          "public_timestamp": "2013-10-24T09:30:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/statistics/early-years-foundation-stage-profile-results-2012-to-2013",
           "document_type": "edition"
         },
         {
@@ -2515,14 +2482,36 @@
           "document_type": "edition"
         },
         {
-          "title": "EYFSP attainment by pupil characteristics: 2010 to 2011",
-          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2010 to 2011.",
-          "link": "/government/statistics/early-years-foundation-stage-profile-attainment-by-pupil-characteristics-academic-year-2010-to-2011",
+          "title": "Integrated review at age 2: implementation study",
+          "description": "Exploring the effect of integrating the early years foundation stage (EYFS) progress check with the healthy child programme (HCP) check.",
+          "link": "/government/publications/integrated-review-at-age-2-implementation-study",
           "format": "publication",
-          "public_timestamp": "2011-12-01T00:01:00.000+00:00",
+          "public_timestamp": "2014-11-21T09:30:04.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/statistics/early-years-foundation-stage-profile-attainment-by-pupil-characteristics-academic-year-2010-to-2011",
+          "_id": "/government/publications/integrated-review-at-age-2-implementation-study",
+          "document_type": "edition"
+        },
+        {
+          "title": "Early years foundation stage profile results: 2012 to 2013",
+          "description": "Early years foundation stage profile (EYFSP) results in England, for the 2012 to 2013 academic year, at national and local authority level.",
+          "link": "/government/statistics/early-years-foundation-stage-profile-results-2012-to-2013",
+          "format": "publication",
+          "public_timestamp": "2013-10-24T09:30:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/statistics/early-years-foundation-stage-profile-results-2012-to-2013",
+          "document_type": "edition"
+        },
+        {
+          "title": "Results of the early years foundation stage profile pilot",
+          "description": "This report describes the results of the pilot to support the introduction of the new profile.",
+          "link": "/government/publications/results-of-the-early-years-foundation-stage-profile-pilot",
+          "format": "publication",
+          "public_timestamp": "2013-03-27T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/results-of-the-early-years-foundation-stage-profile-pilot",
           "document_type": "edition"
         },
         {
@@ -2534,17 +2523,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/the-impact-of-the-early-years-foundation-stage",
-          "document_type": "edition"
-        },
-        {
-          "title": "New early years framework published",
-          "description": "An announcement on the new EYFS framework to support children's learning and development. The early learning goals are reduced from 69 to 17. ",
-          "link": "/government/news/new-early-years-framework-published",
-          "format": "news_article",
-          "public_timestamp": "2012-03-27T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/new-early-years-framework-published",
           "document_type": "edition"
         },
         {
@@ -2570,6 +2548,17 @@
           "document_type": "edition"
         },
         {
+          "title": "EYFSP attainment by pupil characteristics: 2010 to 2011",
+          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2010 to 2011.",
+          "link": "/government/statistics/early-years-foundation-stage-profile-attainment-by-pupil-characteristics-academic-year-2010-to-2011",
+          "format": "publication",
+          "public_timestamp": "2011-12-01T00:01:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/statistics/early-years-foundation-stage-profile-attainment-by-pupil-characteristics-academic-year-2010-to-2011",
+          "document_type": "edition"
+        },
+        {
           "title": "EYFS learning and development requirements: exemptions for providers",
           "description": "What early years providers and independent schools must do to be exempt from some aspects of the early years foundation stage (EYFS).",
           "link": "/government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-early-years-providers",
@@ -2581,6 +2570,17 @@
           "document_type": "edition"
         },
         {
+          "title": "New early years framework published",
+          "description": "An announcement on the new EYFS framework to support children's learning and development. The early learning goals are reduced from 69 to 17. ",
+          "link": "/government/news/new-early-years-framework-published",
+          "format": "news_article",
+          "public_timestamp": "2012-03-27T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/new-early-years-framework-published",
+          "document_type": "edition"
+        },
+        {
           "title": "Pre-school and early home learning: effects on A level outcomes",
           "description": "Report looking at whether pre-school and early home learning helps students gain more A levels.",
           "link": "/government/publications/pre-school-and-early-home-learning-effects-on-a-level-outcomes",
@@ -2589,6 +2589,28 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/pre-school-and-early-home-learning-effects-on-a-level-outcomes",
+          "document_type": "edition"
+        },
+        {
+          "title": "Early years foundation stage profile results: 2010 to 2011",
+          "description": "Results of the 2011 early years foundation stage profile (EYFSP) assessments at a national and local-authority level.",
+          "link": "/government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2010-to-2011",
+          "format": "publication",
+          "public_timestamp": "2011-11-11T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2010-to-2011",
+          "document_type": "edition"
+        },
+        {
+          "title": "Assessment updates for schools",
+          "description": "Information about the Standards and Testing Agency's email newsletters for early years providers and key stage 1 and key stage 2 schools.",
+          "link": "/government/news/assessment-updates-for-schools",
+          "format": "news_article",
+          "public_timestamp": "2015-03-19T11:40:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/assessment-updates-for-schools",
           "document_type": "edition"
         },
         {
@@ -2625,28 +2647,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Assessment updates for schools",
-          "description": "Information about the Standards and Testing Agency's email newsletters for early years providers and key stage 1 and key stage 2 schools.",
-          "link": "/government/news/assessment-updates-for-schools",
-          "format": "news_article",
-          "public_timestamp": "2015-03-19T11:40:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/assessment-updates-for-schools",
-          "document_type": "edition"
-        },
-        {
-          "title": "Early years foundation stage profile results: 2010 to 2011",
-          "description": "Results of the 2011 early years foundation stage profile (EYFSP) assessments at a national and local-authority level.",
-          "link": "/government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2010-to-2011",
-          "format": "publication",
-          "public_timestamp": "2011-11-11T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2010-to-2011",
-          "document_type": "edition"
-        },
-        {
           "title": "Practitioners' experiences of the early years foundation stage",
           "description": "This research report describes the context, design, conduct and findings of an inquiry into practitioners' experiences of the early years foundation stage. ",
           "link": "/government/publications/practitioners-experiences-of-the-early-years-foundation-stage",
@@ -2658,25 +2658,24 @@
           "document_type": "edition"
         },
         {
-          "title": "EYFSP attainment by pupil characteristics: 2012 to 2013",
-          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2012 to 2013.",
-          "link": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013",
-          "format": "publication",
-          "public_timestamp": "2013-11-21T09:53:00.000+00:00",
+          "title": "Early years foundation stage profile results: 2015 to 2016 - additional tables containing characteristic breakdowns ",
+          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2015 to 2016.",
+          "link": "/government/statistics/announcements/early-years-foundation-stage-profile-results-2015-to-2016-additional-tables-containing-characteristic-breakdowns",
+          "format": "statistics_announcement",
           "index": "government",
           "es_score": null,
-          "_id": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013",
+          "_id": "/government/statistics/announcements/early-years-foundation-stage-profile-results-2015-to-2016-additional-tables-containing-characteristic-breakdowns",
           "document_type": "edition"
         },
         {
-          "title": "Achievement of children in the early years foundation stage profile",
-          "description": "Report on children's achievement by the end of the EYFS to find the proportion of children achieving a good level of development.",
-          "link": "/government/publications/achievement-of-children-in-the-early-years-foundation-stage-profile",
+          "title": "Early years foundation stage profile return 2015: guide",
+          "description": "Guide for local authorities and schools submitting early years foundation stage profile (EYFSP) data for 2015.",
+          "link": "/government/publications/early-years-foundation-stage-profile-return-2015-guide",
           "format": "publication",
-          "public_timestamp": "2010-09-30T01:00:00.000+01:00",
+          "public_timestamp": "2015-05-27T10:52:08.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/achievement-of-children-in-the-early-years-foundation-stage-profile",
+          "_id": "/government/publications/early-years-foundation-stage-profile-return-2015-guide",
           "document_type": "edition"
         },
         {
@@ -2691,13 +2690,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Early years foundation stage profile results: 2015 to 2016 - additional tables containing characteristic breakdowns ",
-          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2015 to 2016.",
-          "link": "/government/statistics/announcements/early-years-foundation-stage-profile-results-2015-to-2016-additional-tables-containing-characteristic-breakdowns",
-          "format": "statistics_announcement",
+          "title": "Surveys of practitioners with early years professional status",
+          "description": "Findings from national surveys of practitioners who've achieved early years professional status.",
+          "link": "/government/publications/first-national-survey-of-practitioners-with-early-years-professional-status",
+          "format": "publication",
+          "public_timestamp": "2011-01-15T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/statistics/announcements/early-years-foundation-stage-profile-results-2015-to-2016-additional-tables-containing-characteristic-breakdowns",
+          "_id": "/government/publications/first-national-survey-of-practitioners-with-early-years-professional-status",
+          "document_type": "edition"
+        },
+        {
+          "title": "Achievement of children in the early years foundation stage profile",
+          "description": "Report on children's achievement by the end of the EYFS to find the proportion of children achieving a good level of development.",
+          "link": "/government/publications/achievement-of-children-in-the-early-years-foundation-stage-profile",
+          "format": "publication",
+          "public_timestamp": "2010-09-30T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/achievement-of-children-in-the-early-years-foundation-stage-profile",
           "document_type": "edition"
         },
         {
@@ -2734,25 +2745,14 @@
           "document_type": "edition"
         },
         {
-          "title": "EYFS learning and development requirements: exemptions for children",
-          "description": "What early years settings need to do to disapply or modify some aspects of the early years foundation stage (EYFS) for an individual child.",
-          "link": "/government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-individual-children",
+          "title": "EYFSP attainment by pupil characteristics: 2012 to 2013",
+          "description": "Early years foundation stage profile (EYFSP) assessments, by pupil characteristics in England, for academic year 2012 to 2013.",
+          "link": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013",
           "format": "publication",
-          "public_timestamp": "2012-08-05T01:00:00.000+01:00",
+          "public_timestamp": "2013-11-21T09:53:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-individual-children",
-          "document_type": "edition"
-        },
-        {
-          "title": "Children's experiences of the early years foundation stage",
-          "description": "This project gathered children's views on their experiences in a range of early years settings.",
-          "link": "/government/publications/childrens-experiences-of-the-early-years-foundation-stage",
-          "format": "publication",
-          "public_timestamp": "2010-12-23T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/childrens-experiences-of-the-early-years-foundation-stage",
+          "_id": "/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013",
           "document_type": "edition"
         },
         {
@@ -2767,6 +2767,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Children's experiences of the early years foundation stage",
+          "description": "This project gathered children's views on their experiences in a range of early years settings.",
+          "link": "/government/publications/childrens-experiences-of-the-early-years-foundation-stage",
+          "format": "publication",
+          "public_timestamp": "2010-12-23T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/childrens-experiences-of-the-early-years-foundation-stage",
+          "document_type": "edition"
+        },
+        {
           "title": "EYFSP attainment by pupil characteristics: England - 2015",
           "description": "National and LA information for early years (under 5s) foundation stage profile assessments in England in the academic year 2015.",
           "link": "/government/statistics/announcements/eyfsp-attainment-by-pupil-characteristics-england-2015",
@@ -2777,14 +2788,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Early years foundation stage profile return 2015: guide",
-          "description": "Guide for local authorities and schools submitting early years foundation stage profile (EYFSP) data for 2015.",
-          "link": "/government/publications/early-years-foundation-stage-profile-return-2015-guide",
+          "title": "EYFS learning and development requirements: exemptions for children",
+          "description": "What early years settings need to do to disapply or modify some aspects of the early years foundation stage (EYFS) for an individual child.",
+          "link": "/government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-individual-children",
           "format": "publication",
-          "public_timestamp": "2015-05-27T10:52:08.000+01:00",
+          "public_timestamp": "2012-08-05T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/early-years-foundation-stage-profile-return-2015-guide",
+          "_id": "/government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-individual-children",
+          "document_type": "edition"
+        },
+        {
+          "title": "Dame Clare Tickell responds to inaccurate reports about her review of the EYFS",
+          "description": "Dame Clare Tickell writes to the Times Educational Supplement about her independent review of the early years foundation stage.",
+          "link": "/government/news/dame-clare-tickell-responds-to-inaccurate-reports-about-her-review-of-the-eyfs",
+          "format": "news_article",
+          "public_timestamp": "2011-04-01T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/dame-clare-tickell-responds-to-inaccurate-reports-about-her-review-of-the-eyfs",
           "document_type": "edition"
         },
         {
@@ -2799,28 +2821,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Surveys of practitioners with early years professional status",
-          "description": "Findings from national surveys of practitioners who've achieved early years professional status.",
-          "link": "/government/publications/first-national-survey-of-practitioners-with-early-years-professional-status",
-          "format": "publication",
-          "public_timestamp": "2011-01-15T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/first-national-survey-of-practitioners-with-early-years-professional-status",
-          "document_type": "edition"
-        },
-        {
-          "title": "Nicky Morgan and David Walliams launch literacy drive",
-          "description": "The Education Secretary and children’s author issue a call to publishers and schools to make English pupils Europe’s most literate.",
-          "link": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
-          "format": "news_article",
-          "public_timestamp": "2015-09-24T09:59:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
-          "document_type": "edition"
-        },
-        {
           "title": "I CAN's early talk programme: evaluation",
           "description": "This evaluates the effect of the programme on the ability of staff to provide high quality communication support in children's centres.",
           "link": "/government/publications/i-cans-early-talk-programme-independent-evaluation-of-the-impact-of-early-talk-on-addressing-speech-communication-and-language-needs-in-sure-start",
@@ -2829,6 +2829,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/i-cans-early-talk-programme-independent-evaluation-of-the-impact-of-early-talk-on-addressing-speech-communication-and-language-needs-in-sure-start",
+          "document_type": "edition"
+        },
+        {
+          "title": "EYFSP return 2014: guide",
+          "description": "A guide for schools and local authorities submitting early years foundation stage profile (EYFSP) returns for 2014.",
+          "link": "/government/publications/eyfsp-return-2014-guide",
+          "format": "publication",
+          "public_timestamp": "2014-06-23T14:48:42.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/eyfsp-return-2014-guide",
           "document_type": "edition"
         },
         {
@@ -2854,6 +2865,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Nicky Morgan and David Walliams launch literacy drive",
+          "description": "The Education Secretary and children’s author issue a call to publishers and schools to make English pupils Europe’s most literate.",
+          "link": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
+          "format": "news_article",
+          "public_timestamp": "2015-09-24T09:59:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
+          "document_type": "edition"
+        },
+        {
           "title": "EYFSP 2013: technical specification",
           "description": "This document defines the scope of, and business rationale for, the early years foundation stage profile (EYFSP) 2013 return.",
           "link": "/government/publications/eyfs-profile-2013-technical-specification",
@@ -2862,17 +2884,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/eyfs-profile-2013-technical-specification",
-          "document_type": "edition"
-        },
-        {
-          "title": "EYFSP 2012: guide",
-          "description": "Information for local authorities to help them collect and return the 2012 early years foundation stage profile (EYFSP).",
-          "link": "/government/publications/early-years-foundation-stage-profile-2012-guide",
-          "format": "publication",
-          "public_timestamp": "2012-04-24T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/early-years-foundation-stage-profile-2012-guide",
           "document_type": "edition"
         },
         {
@@ -2909,25 +2920,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Call for evidence for the review of the early years foundation stage",
-          "description": "Dame Clare Tickell launches a call for evidence to inform the independent review of the early years foundation stage. Includes a link to the online consultation.",
-          "link": "/government/news/call-for-evidence-for-the-review-of-the-early-years-foundation-stage",
-          "format": "news_article",
-          "public_timestamp": "2010-08-02T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/call-for-evidence-for-the-review-of-the-early-years-foundation-stage",
-          "document_type": "edition"
-        },
-        {
-          "title": "EYFSP return 2014: guide",
-          "description": "A guide for schools and local authorities submitting early years foundation stage profile (EYFSP) returns for 2014.",
-          "link": "/government/publications/eyfsp-return-2014-guide",
+          "title": "EYFSP 2012: guide",
+          "description": "Information for local authorities to help them collect and return the 2012 early years foundation stage profile (EYFSP).",
+          "link": "/government/publications/early-years-foundation-stage-profile-2012-guide",
           "format": "publication",
-          "public_timestamp": "2014-06-23T14:48:42.000+01:00",
+          "public_timestamp": "2012-04-24T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/eyfsp-return-2014-guide",
+          "_id": "/government/publications/early-years-foundation-stage-profile-2012-guide",
           "document_type": "edition"
         },
         {
@@ -2953,6 +2953,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Call for evidence for the review of the early years foundation stage",
+          "description": "Dame Clare Tickell launches a call for evidence to inform the independent review of the early years foundation stage. Includes a link to the online consultation.",
+          "link": "/government/news/call-for-evidence-for-the-review-of-the-early-years-foundation-stage",
+          "format": "news_article",
+          "public_timestamp": "2010-08-02T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/call-for-evidence-for-the-review-of-the-early-years-foundation-stage",
+          "document_type": "edition"
+        },
+        {
           "title": "EYFSP 2015: technical specification",
           "description": "This document defines the scope of the early years foundation stage profile (EYFSP) return 2015.",
           "link": "/government/publications/eyfsp-2015-technical-specification",
@@ -2972,17 +2983,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/foundation-learning-national-evaluation",
-          "document_type": "edition"
-        },
-        {
-          "title": "Dame Clare Tickell responds to inaccurate reports about her review of the EYFS",
-          "description": "Dame Clare Tickell writes to the Times Educational Supplement about her independent review of the early years foundation stage.",
-          "link": "/government/news/dame-clare-tickell-responds-to-inaccurate-reports-about-her-review-of-the-eyfs",
-          "format": "news_article",
-          "public_timestamp": "2011-04-01T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/dame-clare-tickell-responds-to-inaccurate-reports-about-her-review-of-the-eyfs",
           "document_type": "edition"
         },
         {
@@ -3173,17 +3173,6 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 assessment and reporting arrangements: PDF format versions",
-          "description": "PDF format versions of the 2016 assessment and reporting arrangements (ARA)",
-          "link": "/government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions",
-          "format": "publication",
-          "public_timestamp": "2016-04-25T17:02:26.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions",
-          "document_type": "edition"
-        },
-        {
           "title": "2016 key stage 1 mathematics: sample test materials, mark schemes and test administration instructions",
           "description": "Sample materials including test papers, mark schemes and test administration instructions, to help teachers prepare for the 2016 tests.",
           "link": "/government/publications/2016-key-stage-1-mathematics-sample-test-materials-mark-schemes-and-test-administration-instructions",
@@ -3250,6 +3239,17 @@
           "document_type": "edition"
         },
         {
+          "title": "2016 assessment and reporting arrangements: PDF format versions",
+          "description": "PDF format versions of the 2016 assessment and reporting arrangements (ARA)",
+          "link": "/government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions",
+          "format": "publication",
+          "public_timestamp": "2016-04-25T17:02:26.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions",
+          "document_type": "edition"
+        },
+        {
           "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 7: Phonics screening check",
           "description": "A summary of key dates, participation details and administration guidance, including monitoring and reporting ",
           "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-7-phonics-screening-check",
@@ -3258,6 +3258,17 @@
           "es_score": null,
           "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-7-phonics-screening-check",
           "document_type": "manual_section"
+        },
+        {
+          "title": "Key stage 1 tests: 2016 English grammar, punctuation and spelling test materials",
+          "description": "English grammar, punctuation and spelling test materials administered to eligible pupils at the end of key stage 1 in May 2016.",
+          "link": "/government/publications/key-stage-1-tests-2016-english-grammar-punctuation-and-spelling-test-materials",
+          "format": "publication",
+          "public_timestamp": "2016-06-03T12:36:54.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-tests-2016-english-grammar-punctuation-and-spelling-test-materials",
+          "document_type": "edition"
         },
         {
           "title": "2016 key stage 1 English reading: sample test materials, mark scheme and test administration instructions",
@@ -3271,14 +3282,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 tests: 2016 English grammar, punctuation and spelling test materials",
-          "description": "English grammar, punctuation and spelling test materials administered to eligible pupils at the end of key stage 1 in May 2016.",
-          "link": "/government/publications/key-stage-1-tests-2016-english-grammar-punctuation-and-spelling-test-materials",
+          "title": "Interim frameworks for teacher assessment at the end of key stage 1 in 2016",
+          "description": "Statutory interim frameworks to support teachers in making an assessment judgement for each pupil at the end of key stage 1 in 2016 only.",
+          "link": "/government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1",
           "format": "publication",
-          "public_timestamp": "2016-06-03T12:36:54.000+01:00",
+          "public_timestamp": "2015-09-17T13:47:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-tests-2016-english-grammar-punctuation-and-spelling-test-materials",
+          "_id": "/government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1",
           "document_type": "edition"
         },
         {
@@ -3304,17 +3315,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Interim frameworks for teacher assessment at the end of key stage 1 in 2016",
-          "description": "Statutory interim frameworks to support teachers in making an assessment judgement for each pupil at the end of key stage 1 in 2016 only.",
-          "link": "/government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1",
-          "format": "publication",
-          "public_timestamp": "2015-09-17T13:47:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1",
-          "document_type": "edition"
-        },
-        {
           "title": "2016 Key stage 1: assessment and reporting arrangements (ARA)",
           "description": "Statutory guidance for headteachers and local authority assessment co-ordinators assessing and reporting the national curriculum for 2015 to 2016.\r\n\r\n",
           "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara",
@@ -3337,17 +3337,6 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 teacher assessment exemplification: KS1 mathematics",
-          "description": "Exemplification material for mathematics to support teacher assessment at the end of key stage 1 in 2016.",
-          "link": "/government/publications/2016-teacher-assessment-exemplification-ks1-mathematics",
-          "format": "publication",
-          "public_timestamp": "2016-04-11T13:53:17.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks1-mathematics",
-          "document_type": "edition"
-        },
-        {
           "title": "National curriculum in England: geography programmes of study",
           "description": "The statutory programmes of study and attainment targets for geography at key stages 1 to 3.",
           "link": "/government/publications/national-curriculum-in-england-geography-programmes-of-study",
@@ -3359,15 +3348,26 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA)",
-          "description": "Statutory guidance for headteachers and local authority assessment co-ordinators assessing and reporting the KS2 national curriculum.",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara",
-          "format": "manual",
-          "public_timestamp": "2016-03-24T15:24:21Z",
-          "index": "mainstream",
+          "title": "2016 teacher assessment exemplification: KS1 mathematics",
+          "description": "Exemplification material for mathematics to support teacher assessment at the end of key stage 1 in 2016.",
+          "link": "/government/publications/2016-teacher-assessment-exemplification-ks1-mathematics",
+          "format": "publication",
+          "public_timestamp": "2016-04-11T13:53:17.000+01:00",
+          "index": "government",
           "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara",
-          "document_type": "manual"
+          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks1-mathematics",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1 tests: 2016 English reading test materials",
+          "description": "English reading test materials administered to eligible pupils at the end of key stage 1 in May 2016. ",
+          "link": "/government/publications/key-stage-1-tests-2016-english-reading-test-materials",
+          "format": "publication",
+          "public_timestamp": "2016-06-03T12:36:29.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-tests-2016-english-reading-test-materials",
+          "document_type": "edition"
         },
         {
           "title": "National curriculum in England: art and design programmes of study",
@@ -3381,15 +3381,15 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 tests: 2016 English reading test materials",
-          "description": "English reading test materials administered to eligible pupils at the end of key stage 1 in May 2016. ",
-          "link": "/government/publications/key-stage-1-tests-2016-english-reading-test-materials",
-          "format": "publication",
-          "public_timestamp": "2016-06-03T12:36:29.000+01:00",
-          "index": "government",
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA)",
+          "description": "Statutory guidance for headteachers and local authority assessment co-ordinators assessing and reporting the KS2 national curriculum.",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara",
+          "format": "manual",
+          "public_timestamp": "2016-03-24T15:24:21Z",
+          "index": "mainstream",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-tests-2016-english-reading-test-materials",
-          "document_type": "edition"
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara",
+          "document_type": "manual"
         },
         {
           "title": "National curriculum in England: languages programmes of study",
@@ -3414,6 +3414,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Key stage 2 tests: how to become a marker",
+          "description": "Find out how to become a marker for the key stage 2 English or mathematics tests or science sampling tests.",
+          "link": "/guidance/key-stage-2-tests-how-to-become-a-marker",
+          "format": "detailed_guidance",
+          "public_timestamp": "2014-06-12T11:35:45.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-how-to-become-a-marker",
+          "document_type": "edition"
+        },
+        {
           "title": "National curriculum in England: music programmes of study",
           "description": "The statutory programmes of study and attainment targets for music at key stages 1 to 3.",
           "link": "/government/publications/national-curriculum-in-england-music-programmes-of-study",
@@ -3422,17 +3433,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/national-curriculum-in-england-music-programmes-of-study",
-          "document_type": "edition"
-        },
-        {
-          "title": "Information for parents: 2016 national curriculum test results at the end of key stage 1",
-          "description": "Information about the 2016 key stage 1 national curriculum tests (often referred to as SATs). ",
-          "link": "/government/publications/information-for-parents-2016-national-curriculum-test-results-at-the-end-of-key-stage-1",
-          "format": "publication",
-          "public_timestamp": "2016-06-03T16:58:16.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/information-for-parents-2016-national-curriculum-test-results-at-the-end-of-key-stage-1",
           "document_type": "edition"
         },
         {
@@ -3447,25 +3447,25 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 national curriculum tests for key stages 1 and 2: information for parents",
-          "description": "Information about the 2016 national curriculum tests (often referred to as SATS)",
-          "link": "/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents",
+          "title": "Information for parents: 2016 national curriculum test results at the end of key stage 1",
+          "description": "Information about the 2016 key stage 1 national curriculum tests (often referred to as SATs). ",
+          "link": "/government/publications/information-for-parents-2016-national-curriculum-test-results-at-the-end-of-key-stage-1",
           "format": "publication",
-          "public_timestamp": "2016-05-03T14:00:00.000+01:00",
+          "public_timestamp": "2016-06-03T16:58:16.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents",
+          "_id": "/government/publications/information-for-parents-2016-national-curriculum-test-results-at-the-end-of-key-stage-1",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2 tests: how to become a marker",
-          "description": "Find out how to become a marker for the key stage 2 English or mathematics tests or science sampling tests.",
-          "link": "/guidance/key-stage-2-tests-how-to-become-a-marker",
+          "title": "Key stage 2 tests: how to use access arrangements",
+          "description": "Guidance for teachers and headteachers about access arrangements for pupils to participate in the 2016 key stage 2 national curriculum tests. ",
+          "link": "/guidance/key-stage-2-tests-how-to-use-access-arrangements",
           "format": "detailed_guidance",
-          "public_timestamp": "2014-06-12T11:35:45.000+01:00",
+          "public_timestamp": "2016-02-12T17:29:43.000+00:00",
           "index": "detailed",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-become-a-marker",
+          "_id": "/guidance/key-stage-2-tests-how-to-use-access-arrangements",
           "document_type": "edition"
         },
         {
@@ -3480,14 +3480,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2 tests: how to use access arrangements",
-          "description": "Guidance for teachers and headteachers about access arrangements for pupils to participate in the 2016 key stage 2 national curriculum tests. ",
-          "link": "/guidance/key-stage-2-tests-how-to-use-access-arrangements",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-02-12T17:29:43.000+00:00",
-          "index": "detailed",
+          "title": "2016 national curriculum tests for key stages 1 and 2: information for parents",
+          "description": "Information about the 2016 national curriculum tests (often referred to as SATS)",
+          "link": "/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents",
+          "format": "publication",
+          "public_timestamp": "2016-05-03T14:00:00.000+01:00",
+          "index": "government",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-use-access-arrangements",
+          "_id": "/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents",
           "document_type": "edition"
         },
         {
@@ -3513,6 +3513,16 @@
           "document_type": "edition"
         },
         {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 4: 2016 national curriculum tests",
+          "description": "Includes information about the new 2016 tests, scaled scores, sample test materials, test frameworks, modified test materials and test orders",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriulum-tests",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriulum-tests",
+          "document_type": "manual_section"
+        },
+        {
           "title": "2016 teacher assessment exemplification: KS1 English reading",
           "description": "Exemplification material for English reading to support teacher assessment at the end of key stage 1 in 2016.",
           "link": "/government/publications/2016-teacher-assessment-exemplification-ks1-english-reading",
@@ -3535,16 +3545,6 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 4: 2016 national curriculum tests",
-          "description": "Includes information about the new 2016 tests, scaled scores, sample test materials, test frameworks, modified test materials and test orders",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriulum-tests",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriulum-tests",
-          "document_type": "manual_section"
-        },
-        {
           "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 9: Teacher assessment",
           "description": "Includes what teachers must assess, details of the interim frameworks, pupils working below the standard of the national curriculum, moderation and reporting",
           "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-9-teacher-assessment",
@@ -3563,27 +3563,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/2016-key-stage-2-mathematics-sample-modified-test-administration-instructions",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 2: Key changes",
-          "description": "A summary of the main changes introduced for 2016",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-2-key-changes",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-2-key-changes",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 teacher assessment exemplification: KS1 science",
-          "description": "Exemplification material for science to support teacher assessment at the end of key stage 1 in 2016.",
-          "link": "/government/publications/2016-teacher-assessment-exemplification-ks1-science",
-          "format": "publication",
-          "public_timestamp": "2016-04-11T13:58:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks1-science",
           "document_type": "edition"
         },
         {
@@ -3608,6 +3587,16 @@
           "document_type": "edition"
         },
         {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 2: Key changes",
+          "description": "A summary of the main changes introduced for 2016",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-2-key-changes",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-2-key-changes",
+          "document_type": "manual_section"
+        },
+        {
           "title": "Pre-key stage 1: pupils working below the test standard in 2016",
           "description": "These interim pre-key stage standards are to be used by teachers to report a statutory assessment outcome for specified pupils at the end of key stage 1.",
           "link": "/government/publications/pre-key-stage-1-pupils-working-below-the-test-standard",
@@ -3617,6 +3606,27 @@
           "es_score": null,
           "_id": "/government/publications/pre-key-stage-1-pupils-working-below-the-test-standard",
           "document_type": "edition"
+        },
+        {
+          "title": "2016 teacher assessment exemplification: KS1 science",
+          "description": "Exemplification material for science to support teacher assessment at the end of key stage 1 in 2016.",
+          "link": "/government/publications/2016-teacher-assessment-exemplification-ks1-science",
+          "format": "publication",
+          "public_timestamp": "2016-04-11T13:58:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks1-science",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 5: Participation in the tests",
+          "description": "How different types of schools participate in the tests, which pupils should take them and details of access arrangements ",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-5-participation-in-the-tests",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-5-participation-in-the-tests",
+          "document_type": "manual_section"
         },
         {
           "title": "2016 teacher assessment exemplification: KS2 English reading",
@@ -3641,17 +3651,6 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 key stage 2 English grammar, punctuation and spelling: sample modified tests",
-          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 2 tests",
-          "link": "/government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
-          "format": "publication",
-          "public_timestamp": "2016-01-26T14:20:26.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
-          "document_type": "edition"
-        },
-        {
           "title": "2016 key stage 2 science sampling test: sample questions, mark scheme and commentary",
           "description": "Information to help teachers prepare for the new tests of the new national curriculum. ",
           "link": "/government/publications/2016-key-stage-2-science-sampling-test-sample-questions-mark-scheme-and-commentary",
@@ -3660,38 +3659,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/2016-key-stage-2-science-sampling-test-sample-questions-mark-scheme-and-commentary",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 5: Participation in the tests",
-          "description": "How different types of schools participate in the tests, which pupils should take them and details of access arrangements ",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-5-participation-in-the-tests",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-5-participation-in-the-tests",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 key stage 1 English grammar, punctuation and spelling: sample modified tests",
-          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
-          "link": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
-          "format": "publication",
-          "public_timestamp": "2016-04-26T10:53:26.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
-          "document_type": "edition"
-        },
-        {
-          "title": "Teacher assessment moderation: requirements for key stage 2",
-          "description": "Guidance and requirements to support schools and local authorities involved in key stage 2 teacher assessment and statutory moderation in 2016.",
-          "link": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-2",
-          "format": "publication",
-          "public_timestamp": "2016-03-24T17:16:05.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-2",
           "document_type": "edition"
         },
         {
@@ -3716,58 +3683,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 tests: test administration guidance (TAG)",
-          "description": "Guidance for headteachers, teachers and teaching assistants on administering the 2016 key stage 1 national curriculum tests (SATs).",
-          "link": "/government/publications/key-stage-1-tests-test-administration-guidance-tag",
+          "title": "Teacher assessment moderation: requirements for key stage 2",
+          "description": "Guidance and requirements to support schools and local authorities involved in key stage 2 teacher assessment and statutory moderation in 2016.",
+          "link": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-2",
           "format": "publication",
-          "public_timestamp": "2016-04-29T15:39:51.000+01:00",
+          "public_timestamp": "2016-03-24T17:16:05.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-tests-test-administration-guidance-tag",
+          "_id": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-2",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 tests: how to use access arrangements",
-          "description": "Guidance for teachers and headteachers about access arrangements for pupils to participate in the 2016 key stage 1 national curriculum tests. ",
-          "link": "/guidance/key-stage-1-tests-how-to-use-access-arrangements",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-03-18T13:56:45.000+00:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-1-tests-how-to-use-access-arrangements",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: notes for teachers on how the English grammar, punctuation and spelling test is marked",
-          "description": "Guidance for teachers about how pupil responses are marked in the key stage 2 English grammar, punctuation and spelling test.",
-          "link": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-the-english-grammar-punctuation-and-spelling-test-is-marked",
+          "title": "2016 key stage 2 English grammar, punctuation and spelling: sample modified tests",
+          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 2 tests",
+          "link": "/government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
           "format": "publication",
-          "public_timestamp": "2013-11-01T00:00:00.000+00:00",
+          "public_timestamp": "2016-01-26T14:20:26.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-the-english-grammar-punctuation-and-spelling-test-is-marked",
-          "document_type": "edition"
-        },
-        {
-          "title": "Teacher assessment moderation: requirements for key stage 1",
-          "description": "Guidance and requirements to support schools and local authorities involved in key stage 1 teacher assessment and statutory moderation in 2016.",
-          "link": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-1",
-          "format": "publication",
-          "public_timestamp": "2016-03-24T17:15:01.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-1",
-          "document_type": "edition"
-        },
-        {
-          "title": "National curriculum assessments: guidance for local authorities",
-          "description": "Information for local authorities (LAs) supporting schools' key stage 1 and 2 tests and teacher assessment.",
-          "link": "/government/collections/national-curriculum-assessments-guidance-for-local-authorities",
-          "format": "document_collection",
-          "public_timestamp": "2015-04-17T08:00:55.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/collections/national-curriculum-assessments-guidance-for-local-authorities",
+          "_id": "/government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
           "document_type": "edition"
         },
         {
@@ -3782,28 +3716,6 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 teacher assessment exemplification: KS2 science",
-          "description": "Exemplification material for science to support teacher assessment at the end of key stage 2 in 2016.",
-          "link": "/government/publications/2016-teacher-assessment-exemplification-ks2-science",
-          "format": "publication",
-          "public_timestamp": "2016-04-11T13:59:25.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks2-science",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 key stage 1 mathematics: sample modified tests",
-          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
-          "link": "/government/publications/2016-key-stage-1-mathematics-sample-modified-test-administration-instructions",
-          "format": "publication",
-          "public_timestamp": "2016-01-26T14:23:01.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-key-stage-1-mathematics-sample-modified-test-administration-instructions",
-          "document_type": "edition"
-        },
-        {
           "title": "Rochford Review: interim recommendations",
           "description": "This report provides guidance to schools about how to report statutory assessment outcomes for pupils working below the standard of the national curriculum tests at key stages 1 and 2.",
           "link": "/government/publications/rochford-review-interim-recommendations",
@@ -3815,35 +3727,46 @@
           "document_type": "edition"
         },
         {
-          "title": "Notes for readers in the 2016 English grammar, punctuation and spelling tests at key stage 1 and key stage 2",
-          "description": "Examples of how to read out particular types of questions in the English grammar, punctuation and spelling tests ",
-          "link": "/government/publications/notes-for-readers-in-the-english-grammar-punctuation-and-spelling-test-short-answer-questions",
+          "title": "2016 teacher assessment exemplification: KS2 science",
+          "description": "Exemplification material for science to support teacher assessment at the end of key stage 2 in 2016.",
+          "link": "/government/publications/2016-teacher-assessment-exemplification-ks2-science",
           "format": "publication",
-          "public_timestamp": "2016-03-31T18:51:36.000+01:00",
+          "public_timestamp": "2016-04-11T13:59:25.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/notes-for-readers-in-the-english-grammar-punctuation-and-spelling-test-short-answer-questions",
+          "_id": "/government/publications/2016-teacher-assessment-exemplification-ks2-science",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2: science sampling tests",
-          "description": "Information for headteachers and teachers explaining how science is tested at key stage 2.",
-          "link": "/government/publications/key-stage-2-science-sampling-tests",
+          "title": "Teacher assessment moderation: requirements for key stage 1",
+          "description": "Guidance and requirements to support schools and local authorities involved in key stage 1 teacher assessment and statutory moderation in 2016.",
+          "link": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-1",
           "format": "publication",
-          "public_timestamp": "2016-04-25T15:12:49.000+01:00",
+          "public_timestamp": "2016-03-24T17:15:01.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-2-science-sampling-tests",
+          "_id": "/government/publications/teacher-assessment-moderation-requirements-for-key-stage-1",
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 10: Test results",
-          "description": "Details about the return of results to schools, reviews of marking and how the results are used ",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-10-test-results",
+          "title": "2016 key stage 1 English grammar, punctuation and spelling: sample modified tests",
+          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
+          "link": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
+          "format": "publication",
+          "public_timestamp": "2016-04-26T10:53:26.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 3: Key dates",
+          "description": "Dates throughout the 2015 to 2016 assessment cycle",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-3-key-dates",
           "format": "manual_section",
           "index": "mainstream",
           "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-10-test-results",
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-3-key-dates",
           "document_type": "manual_section"
         },
         {
@@ -3858,46 +3781,14 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 3: Key dates",
-          "description": "Dates throughout the 2015 to 2016 assessment cycle",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-3-key-dates",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-3-key-dates",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "Key stage 2 tests: how to apply for a review of key stage 2 national curriculum test results",
-          "description": "Information for headteachers about applying for a review of marking for the key stage 2 tests.",
-          "link": "/guidance/key-stage-2-tests-how-to-apply-for-a-review-of-key-stage-2-results",
+          "title": "Key stage 1 tests: how to use access arrangements",
+          "description": "Guidance for teachers and headteachers about access arrangements for pupils to participate in the 2016 key stage 1 national curriculum tests. ",
+          "link": "/guidance/key-stage-1-tests-how-to-use-access-arrangements",
           "format": "detailed_guidance",
-          "public_timestamp": "2016-06-10T16:43:22.000+01:00",
+          "public_timestamp": "2016-03-18T13:56:45.000+00:00",
           "index": "detailed",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-a-review-of-key-stage-2-results",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 key stage 2 English reading: sample modified tests",
-          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 2 tests",
-          "link": "/government/publications/2016-key-stage-2-english-reading-sample-modified-test-administration-instructions",
-          "format": "publication",
-          "public_timestamp": "2016-01-26T14:19:15.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2016-key-stage-2-english-reading-sample-modified-test-administration-instructions",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: notes for teachers on how to prepare for onscreen marking",
-          "description": "Guidance for teachers about how to ensure that pupils’ national curriculum test scripts can be scanned and their answers read and marked on screen.",
-          "link": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-to-prepare-for-onscreen-marking",
-          "format": "publication",
-          "public_timestamp": "2016-05-04T14:14:29.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-to-prepare-for-onscreen-marking",
+          "_id": "/guidance/key-stage-1-tests-how-to-use-access-arrangements",
           "document_type": "edition"
         },
         {
@@ -3912,6 +3803,17 @@
           "document_type": "edition"
         },
         {
+          "title": "2016 key stage 1 mathematics: sample modified tests",
+          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
+          "link": "/government/publications/2016-key-stage-1-mathematics-sample-modified-test-administration-instructions",
+          "format": "publication",
+          "public_timestamp": "2016-01-26T14:23:01.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-key-stage-1-mathematics-sample-modified-test-administration-instructions",
+          "document_type": "edition"
+        },
+        {
           "title": "Key stage 2 tests: how to access results and test scripts",
           "description": "Information for headteachers, teachers and local authorities on how to access test results, scripts, scaled score conversion tables and materials.",
           "link": "/guidance/key-stage-2-tests-how-to-access-results-and-test-scripts",
@@ -3920,6 +3822,17 @@
           "index": "detailed",
           "es_score": null,
           "_id": "/guidance/key-stage-2-tests-how-to-access-results-and-test-scripts",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: how to apply for a review of key stage 2 national curriculum test results",
+          "description": "Information for headteachers about applying for a review of marking for the key stage 2 tests.",
+          "link": "/guidance/key-stage-2-tests-how-to-apply-for-a-review-of-key-stage-2-results",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-06-10T16:43:22.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-a-review-of-key-stage-2-results",
           "document_type": "edition"
         },
         {
@@ -3933,14 +3846,57 @@
           "document_type": "manual_section"
         },
         {
-          "title": "Key stage 2 tests: guide to registering pupils for the tests",
-          "description": "Information for headteachers and teachers on how to complete pupil registration for the key stage 2 national curriculum tests.",
-          "link": "/guidance/key-stage-2-tests-guide-to-registering-pupils-for-the-tests",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-02-19T17:53:54.000+00:00",
-          "index": "detailed",
+          "title": "Notes for readers in the 2016 English grammar, punctuation and spelling tests at key stage 1 and key stage 2",
+          "description": "Examples of how to read out particular types of questions in the English grammar, punctuation and spelling tests ",
+          "link": "/government/publications/notes-for-readers-in-the-english-grammar-punctuation-and-spelling-test-short-answer-questions",
+          "format": "publication",
+          "public_timestamp": "2016-03-31T18:51:36.000+01:00",
+          "index": "government",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-guide-to-registering-pupils-for-the-tests",
+          "_id": "/government/publications/notes-for-readers-in-the-english-grammar-punctuation-and-spelling-test-short-answer-questions",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 10: Test results",
+          "description": "Details about the return of results to schools, reviews of marking and how the results are used ",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-10-test-results",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-10-test-results",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "2016 key stage 2 English reading: sample modified tests",
+          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 2 tests",
+          "link": "/government/publications/2016-key-stage-2-english-reading-sample-modified-test-administration-instructions",
+          "format": "publication",
+          "public_timestamp": "2016-01-26T14:19:15.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-key-stage-2-english-reading-sample-modified-test-administration-instructions",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: notes for teachers on how the English grammar, punctuation and spelling test is marked",
+          "description": "Guidance for teachers about how pupil responses are marked in the key stage 2 English grammar, punctuation and spelling test.",
+          "link": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-the-english-grammar-punctuation-and-spelling-test-is-marked",
+          "format": "publication",
+          "public_timestamp": "2013-11-01T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-the-english-grammar-punctuation-and-spelling-test-is-marked",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1 tests: test administration guidance (TAG)",
+          "description": "Guidance for headteachers, teachers and teaching assistants on administering the 2016 key stage 1 national curriculum tests (SATs).",
+          "link": "/government/publications/key-stage-1-tests-test-administration-guidance-tag",
+          "format": "publication",
+          "public_timestamp": "2016-04-29T15:39:51.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-tests-test-administration-guidance-tag",
           "document_type": "edition"
         },
         {
@@ -3955,14 +3911,58 @@
           "document_type": "edition"
         },
         {
-          "title": "2016 key stage 1 English reading: sample modified tests",
-          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
-          "link": "/government/publications/2016-key-stage-1-english-reading-sample-modified-test-administration-instructions",
-          "format": "publication",
-          "public_timestamp": "2016-01-26T14:24:04.000+00:00",
+          "title": "National curriculum assessments: guidance for local authorities",
+          "description": "Information for local authorities (LAs) supporting schools' key stage 1 and 2 tests and teacher assessment.",
+          "link": "/government/collections/national-curriculum-assessments-guidance-for-local-authorities",
+          "format": "document_collection",
+          "public_timestamp": "2015-04-17T08:00:55.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/2016-key-stage-1-english-reading-sample-modified-test-administration-instructions",
+          "_id": "/government/collections/national-curriculum-assessments-guidance-for-local-authorities",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: applying special consideration to results",
+          "description": "How a pupil's results in the key stage 2 tests can be changed if a pupil is affected by extremely distressing circumstances.",
+          "link": "/guidance/key-stage-2-tests-applying-special-consideration-to-results",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-07-05T00:02:00.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-applying-special-consideration-to-results",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2: English grammar, punctuation and spelling test framework",
+          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 2 English grammar, punctuation and spelling test.",
+          "link": "/government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-framework",
+          "format": "publication",
+          "public_timestamp": "2016-03-24T15:44:40.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-framework",
+          "document_type": "edition"
+        },
+        {
+          "title": "Getting them reading early",
+          "description": "This will be of interest to teachers, providers of initial and in-service teacher education, and Ofsted inspectors.",
+          "link": "/government/publications/getting-them-reading-early",
+          "format": "publication",
+          "public_timestamp": "2014-10-13T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/getting-them-reading-early",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2: science sampling tests",
+          "description": "Information for headteachers and teachers explaining how science is tested at key stage 2.",
+          "link": "/government/publications/key-stage-2-science-sampling-tests",
+          "format": "publication",
+          "public_timestamp": "2016-04-25T15:12:49.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-science-sampling-tests",
           "document_type": "edition"
         },
         {
@@ -3977,6 +3977,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Key stage 2: mathematics test framework",
+          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 2 mathematics test.",
+          "link": "/government/publications/key-stage-2-mathematics-test-framework",
+          "format": "publication",
+          "public_timestamp": "2015-07-09T17:11:39.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-mathematics-test-framework",
+          "document_type": "edition"
+        },
+        {
           "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 11: Reporting to parents",
           "description": "Contains information about what reports must cover and reporting on pupils who change schools",
           "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-11-reporting-to-parents",
@@ -3987,14 +3998,69 @@
           "document_type": "manual_section"
         },
         {
-          "title": "Key stage 2 tests: applying special consideration to results",
-          "description": "How a pupil's results in the key stage 2 tests can be changed if a pupil is affected by extremely distressing circumstances.",
-          "link": "/guidance/key-stage-2-tests-applying-special-consideration-to-results",
+          "title": "New national curriculum: primary assessment and accountability",
+          "description": "Primary assessment and accountability consultation following the publication of the new national curriculum.",
+          "link": "/government/consultations/new-national-curriculum-primary-assessment-and-accountability",
+          "format": "consultation",
+          "public_timestamp": "2014-03-27T09:30:17.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/consultations/new-national-curriculum-primary-assessment-and-accountability",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1 tests: standard setting",
+          "description": "Information for schools about the standard setting process for key stage 1 national curriculum tests in 2016.",
+          "link": "/guidance/key-stage-1-tests-standard-setting",
           "format": "detailed_guidance",
-          "public_timestamp": "2016-07-05T00:02:00.000+01:00",
+          "public_timestamp": "2016-06-03T12:22:41.000+01:00",
           "index": "detailed",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-applying-special-consideration-to-results",
+          "_id": "/guidance/key-stage-1-tests-standard-setting",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1: English grammar, punctuation and spelling test framework",
+          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 1 English grammar, punctuation and spelling test.",
+          "link": "/government/publications/key-stage-1-english-grammar-punctuation-and-spelling-test-framework",
+          "format": "publication",
+          "public_timestamp": "2016-03-24T15:43:55.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-english-grammar-punctuation-and-spelling-test-framework",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: guide to registering pupils for the tests",
+          "description": "Information for headteachers and teachers on how to complete pupil registration for the key stage 2 national curriculum tests.",
+          "link": "/guidance/key-stage-2-tests-guide-to-registering-pupils-for-the-tests",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-02-19T17:53:54.000+00:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-guide-to-registering-pupils-for-the-tests",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 key stage 1 English reading: sample modified tests",
+          "description": "Sample materials for administering the Modified Large Print (MLP) and braille versions of the key stage 1 tests",
+          "link": "/government/publications/2016-key-stage-1-english-reading-sample-modified-test-administration-instructions",
+          "format": "publication",
+          "public_timestamp": "2016-01-26T14:24:04.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2016-key-stage-1-english-reading-sample-modified-test-administration-instructions",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: how to apply for special consideration",
+          "description": "Information for teachers about applying for special consideration to be applied to a pupil's test result if the pupil has been affected by extremely distressing circumstances.",
+          "link": "/guidance/key-stage-2-tests-how-to-apply-for-special-consideration",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-05-06T17:07:04.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-special-consideration",
           "document_type": "edition"
         },
         {
@@ -4020,69 +4086,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Getting them reading early",
-          "description": "This will be of interest to teachers, providers of initial and in-service teacher education, and Ofsted inspectors.",
-          "link": "/government/publications/getting-them-reading-early",
+          "title": "Key stage 2 tests: notes for teachers on how to prepare for onscreen marking",
+          "description": "Guidance for teachers about how to ensure that pupils’ national curriculum test scripts can be scanned and their answers read and marked on screen.",
+          "link": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-to-prepare-for-onscreen-marking",
           "format": "publication",
-          "public_timestamp": "2014-10-13T01:00:00.000+01:00",
+          "public_timestamp": "2016-05-04T14:14:29.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/getting-them-reading-early",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 1: English grammar, punctuation and spelling test framework",
-          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 1 English grammar, punctuation and spelling test.",
-          "link": "/government/publications/key-stage-1-english-grammar-punctuation-and-spelling-test-framework",
-          "format": "publication",
-          "public_timestamp": "2016-03-24T15:43:55.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-1-english-grammar-punctuation-and-spelling-test-framework",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2: English grammar, punctuation and spelling test framework",
-          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 2 English grammar, punctuation and spelling test.",
-          "link": "/government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-framework",
-          "format": "publication",
-          "public_timestamp": "2016-03-24T15:44:40.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-framework",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2: mathematics test framework",
-          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 2 mathematics test.",
-          "link": "/government/publications/key-stage-2-mathematics-test-framework",
-          "format": "publication",
-          "public_timestamp": "2015-07-09T17:11:39.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-mathematics-test-framework",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: how to apply for special consideration",
-          "description": "Information for teachers about applying for special consideration to be applied to a pupil's test result if the pupil has been affected by extremely distressing circumstances.",
-          "link": "/guidance/key-stage-2-tests-how-to-apply-for-special-consideration",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-05-06T17:07:04.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-special-consideration",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 1 tests: standard setting",
-          "description": "Information for schools about the standard setting process for key stage 1 national curriculum tests in 2016.",
-          "link": "/guidance/key-stage-1-tests-standard-setting",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-06-03T12:22:41.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-1-tests-standard-setting",
+          "_id": "/government/publications/key-stage-2-tests-notes-for-teachers-on-how-to-prepare-for-onscreen-marking",
           "document_type": "edition"
         },
         {
@@ -4108,98 +4119,14 @@
           "document_type": "edition"
         },
         {
-          "title": "New national curriculum: primary assessment and accountability",
-          "description": "Primary assessment and accountability consultation following the publication of the new national curriculum.",
-          "link": "/government/consultations/new-national-curriculum-primary-assessment-and-accountability",
-          "format": "consultation",
-          "public_timestamp": "2014-03-27T09:30:17.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/consultations/new-national-curriculum-primary-assessment-and-accountability",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 8: Science sampling",
-          "description": "Key dates, test administration and results for the biennial science sampling tests ",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-8-science-sampling",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-8-science-sampling",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 3: Key dates",
-          "description": "Dates throughout the 2015 to 2016 assessment cycle",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 1: Introduction",
-          "description": "About the 2016 KS1 ARA and how to use the new manuals format",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "A whole-school approach to art, craft and design",
-          "description": "Ofsted good practice example showing how Aston Fence Junior and Infant School gets high achievement in art, craft and design.",
-          "link": "/government/publications/a-whole-school-approach-to-art-craft-and-design",
+          "title": "Key stage 1: mathematics test framework",
+          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 1 mathematics test.",
+          "link": "/government/publications/key-stage-1-mathematics-test-framework",
           "format": "publication",
-          "public_timestamp": "2014-01-06T00:00:00.000+00:00",
+          "public_timestamp": "2015-06-29T17:24:13.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/a-whole-school-approach-to-art-craft-and-design",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: modified test administration guidance (MTAG)",
-          "description": "Guidance for headteachers, teachers and teaching assistants on administering the 2016 key stage 2 national curriculum tests (SATs) to pupils with hearing or visual impairments.",
-          "link": "/government/publications/key-stage-2-tests-modified-test-administration-guidance-mtag",
-          "format": "publication",
-          "public_timestamp": "2016-04-11T14:35:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-tests-modified-test-administration-guidance-mtag",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 9: Reporting to parents",
-          "description": "Contains information about what reports must cover and reporting on pupils who change schools",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-9-reporting-to-parents",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-9-reporting-to-parents",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "Removing barriers to literacy",
-          "description": "Ofsted survey report illustrating effective approaches in literacy that might help others to improve their practice.",
-          "link": "/government/publications/removing-barriers-to-literacy",
-          "format": "publication",
-          "public_timestamp": "2011-01-21T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/removing-barriers-to-literacy",
-          "document_type": "edition"
-        },
-        {
-          "title": "Pre-key stage 2: pupils working below the test standard in 2016",
-          "description": "Interim pre-key stage standards to be used by teachers to report a statutory assessment outcome for specified pupils at the end of key stage 2",
-          "link": "/government/publications/pre-key-stage-2-pupils-working-below-the-test-standard",
-          "format": "publication",
-          "public_timestamp": "2015-12-11T09:47:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/pre-key-stage-2-pupils-working-below-the-test-standard",
+          "_id": "/government/publications/key-stage-1-mathematics-test-framework",
           "document_type": "edition"
         },
         {
@@ -4214,57 +4141,87 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 tests: modified test administration guidance (MTAG)",
-          "description": "Guidance for administering the 2016 national curriculum tests (SATs) to pupils with hearing or visual impairments.",
-          "link": "/government/publications/key-stage-1-tests-modified-test-administration-guidance-mtag",
+          "title": "Key stage 2 tests: modified test administration guidance (MTAG)",
+          "description": "Guidance for headteachers, teachers and teaching assistants on administering the 2016 key stage 2 national curriculum tests (SATs) to pupils with hearing or visual impairments.",
+          "link": "/government/publications/key-stage-2-tests-modified-test-administration-guidance-mtag",
           "format": "publication",
-          "public_timestamp": "2016-05-04T14:17:36.000+01:00",
+          "public_timestamp": "2016-04-11T14:35:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-tests-modified-test-administration-guidance-mtag",
+          "_id": "/government/publications/key-stage-2-tests-modified-test-administration-guidance-mtag",
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 12: Keeping and maintaining records",
-          "description": "Information on disclosure of educational records and transferring records to a pupil's new school",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-12-keeping-and-maintaining-records",
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 3: Key dates",
+          "description": "Dates throughout the 2015 to 2016 assessment cycle",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates",
           "format": "manual_section",
           "index": "mainstream",
           "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-12-keeping-and-maintaining-records",
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates",
           "document_type": "manual_section"
         },
         {
-          "title": "Geography: learning to make a world of difference",
-          "description": "Ofsted survey report evaluating the strengths and weaknesses of geography in schools and assessing the challenges it faces.",
-          "link": "/government/publications/geography-learning-to-make-a-world-of-difference",
+          "title": "Removing barriers to literacy",
+          "description": "Ofsted survey report illustrating effective approaches in literacy that might help others to improve their practice.",
+          "link": "/government/publications/removing-barriers-to-literacy",
           "format": "publication",
-          "public_timestamp": "2011-02-04T00:00:00.000+00:00",
+          "public_timestamp": "2011-01-21T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/geography-learning-to-make-a-world-of-difference",
+          "_id": "/government/publications/removing-barriers-to-literacy",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 and 2: maladministration investigation procedures",
-          "description": "STA’s procedures for considering maladministration allegations into the phonics screening check, key stage 1 and key stage 2 tests or teacher assessment. ",
-          "link": "/government/publications/key-stage-1-and-2-maladministration-investigation-procedures",
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 1: Introduction",
+          "description": "About the 2016 KS1 ARA and how to use the new manuals format",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 9: Reporting to parents",
+          "description": "Contains information about what reports must cover and reporting on pupils who change schools",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-9-reporting-to-parents",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-9-reporting-to-parents",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "A whole-school approach to art, craft and design",
+          "description": "Ofsted good practice example showing how Aston Fence Junior and Infant School gets high achievement in art, craft and design.",
+          "link": "/government/publications/a-whole-school-approach-to-art-craft-and-design",
           "format": "publication",
-          "public_timestamp": "2016-04-29T16:05:11.000+01:00",
+          "public_timestamp": "2014-01-06T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-and-2-maladministration-investigation-procedures",
+          "_id": "/government/publications/a-whole-school-approach-to-art-craft-and-design",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1: mathematics test framework",
-          "description": "Guidance for test developers on the purpose, format, content, cognitive demand and specification for the key stage 1 mathematics test.",
-          "link": "/government/publications/key-stage-1-mathematics-test-framework",
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 8: Science sampling",
+          "description": "Key dates, test administration and results for the biennial science sampling tests ",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-8-science-sampling",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-8-science-sampling",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "Pre-key stage 2: pupils working below the test standard in 2016",
+          "description": "Interim pre-key stage standards to be used by teachers to report a statutory assessment outcome for specified pupils at the end of key stage 2",
+          "link": "/government/publications/pre-key-stage-2-pupils-working-below-the-test-standard",
           "format": "publication",
-          "public_timestamp": "2015-06-29T17:24:13.000+01:00",
+          "public_timestamp": "2015-12-11T09:47:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/key-stage-1-mathematics-test-framework",
+          "_id": "/government/publications/pre-key-stage-2-pupils-working-below-the-test-standard",
           "document_type": "edition"
         },
         {
@@ -4279,25 +4236,35 @@
           "document_type": "edition"
         },
         {
-          "title": "Reception baseline comparability study",
-          "description": "A study comparing the 3 reception baseline assessments used by schools in the 2015 to 2016 academic year. ",
-          "link": "/government/publications/reception-baseline-comparability-study",
+          "title": "Geography: learning to make a world of difference",
+          "description": "Ofsted survey report evaluating the strengths and weaknesses of geography in schools and assessing the challenges it faces.",
+          "link": "/government/publications/geography-learning-to-make-a-world-of-difference",
           "format": "publication",
-          "public_timestamp": "2016-04-07T16:48:48.000+01:00",
+          "public_timestamp": "2011-02-04T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/reception-baseline-comparability-study",
+          "_id": "/government/publications/geography-learning-to-make-a-world-of-difference",
           "document_type": "edition"
         },
         {
-          "title": "Food teaching in primary schools: knowledge and skills framework",
-          "description": "Guidance to support primary school teachers deliver food teaching in schools. ",
-          "link": "/government/publications/food-teaching-in-primary-schools-knowledge-and-skills-framework",
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 12: Keeping and maintaining records",
+          "description": "Information on disclosure of educational records and transferring records to a pupil's new school",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-12-keeping-and-maintaining-records",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-12-keeping-and-maintaining-records",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "Key stage 1 tests: modified test administration guidance (MTAG)",
+          "description": "Guidance for administering the 2016 national curriculum tests (SATs) to pupils with hearing or visual impairments.",
+          "link": "/government/publications/key-stage-1-tests-modified-test-administration-guidance-mtag",
           "format": "publication",
-          "public_timestamp": "2015-11-19T14:30:26.000+00:00",
+          "public_timestamp": "2016-05-04T14:17:36.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/food-teaching-in-primary-schools-knowledge-and-skills-framework",
+          "_id": "/government/publications/key-stage-1-tests-modified-test-administration-guidance-mtag",
           "document_type": "edition"
         },
         {
@@ -4311,14 +4278,14 @@
           "document_type": "manual_section"
         },
         {
-          "title": "Primary schools’ test results released",
-          "description": "The results of more than 16,000 schools’ key stage 2 tests – taken by 11-year-olds this May – were published today.",
-          "link": "/government/news/primary-schools-test-results-released--2",
-          "format": "news_article",
-          "public_timestamp": "2011-12-15T00:00:00.000+00:00",
+          "title": "Key stage 1 and 2: maladministration investigation procedures",
+          "description": "STA’s procedures for considering maladministration allegations into the phonics screening check, key stage 1 and key stage 2 tests or teacher assessment. ",
+          "link": "/government/publications/key-stage-1-and-2-maladministration-investigation-procedures",
+          "format": "publication",
+          "public_timestamp": "2016-04-29T16:05:11.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/primary-schools-test-results-released--2",
+          "_id": "/government/publications/key-stage-1-and-2-maladministration-investigation-procedures",
           "document_type": "edition"
         },
         {
@@ -4333,98 +4300,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 and 2: maladministration investigation visits",
-          "description": "Guidance for local authorities about how to carry out a school visit, as part of STA’s investigations in relation to maladministration.",
-          "link": "/guidance/key-stage-1-and-2-school-visits-following-an-allegation-of-maladministration",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-04-29T16:07:30.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-1-and-2-school-visits-following-an-allegation-of-maladministration",
-          "document_type": "edition"
-        },
-        {
-          "title": "Closing the gap with the new primary national curriculum",
-          "description": "This project investigated how the best schools continue to close the gap as they implement the new primary national curriculum.",
-          "link": "/government/publications/closing-the-gap-with-the-new-primary-national-curriculum",
+          "title": "Food teaching in primary schools: knowledge and skills framework",
+          "description": "Guidance to support primary school teachers deliver food teaching in schools. ",
+          "link": "/government/publications/food-teaching-in-primary-schools-knowledge-and-skills-framework",
           "format": "publication",
-          "public_timestamp": "2014-09-01T12:24:00.000+01:00",
+          "public_timestamp": "2015-11-19T14:30:26.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/closing-the-gap-with-the-new-primary-national-curriculum",
+          "_id": "/government/publications/food-teaching-in-primary-schools-knowledge-and-skills-framework",
           "document_type": "edition"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 13: Legal requirements and responsibilities",
-          "description": "Includes information about the legal status of ARA, the application of the ARA to different types of school and headteachers' responsibilities",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-13-legal-requirements-and-responsibilities",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-13-legal-requirements-and-responsibilities",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 6: Test administration",
-          "description": "About the testing window, keeping materials secure, the headteacher's declaration form (HDF) and reporting results ",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-6-test-administration",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-6-test-administration",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "New primary school tests will help eradicate illiteracy and innumeracy",
-          "description": "Sample questions for the tests taken by 7-year-olds and 11-year-olds show the higher standards expected for reading, writing and arithmetic.",
-          "link": "/government/news/new-primary-school-tests-will-help-eradicate-illiteracy-and-innumeracy",
-          "format": "news_article",
-          "public_timestamp": "2014-07-14T16:45:00.000+01:00",
+          "title": "Reception baseline comparability study",
+          "description": "A study comparing the 3 reception baseline assessments used by schools in the 2015 to 2016 academic year. ",
+          "link": "/government/publications/reception-baseline-comparability-study",
+          "format": "publication",
+          "public_timestamp": "2016-04-07T16:48:48.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/new-primary-school-tests-will-help-eradicate-illiteracy-and-innumeracy",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 5: Participation in tests",
-          "description": "How different types of schools participate in the tests, which pupils should take them and details of access arrangements ",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-5-participation-in-tests",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-5-participation-in-tests",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 6: Test administration",
-          "description": "About the testing window, keeping materials secure, the headteacher's declaration form (HDF) and reporting results ",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-6-test-administration",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-6-test-administration",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "Key stage 2 (KS2) testing review reports",
-          "description": "Documents on the key stage 2 (KS2) testing review.",
-          "link": "/government/collections/key-stage-2-ks2-testing-review",
-          "format": "document_collection",
-          "public_timestamp": "2011-06-23T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/collections/key-stage-2-ks2-testing-review",
-          "document_type": "edition"
-        },
-        {
-          "title": "‘Harmful’ ICT curriculum set to be dropped to make way for rigorous computer science",
-          "description": "Gove announces the scrapping the existing ICT curriculum to introduce new courses of study in computer science.",
-          "link": "/government/news/harmful-ict-curriculum-set-to-be-dropped-to-make-way-for-rigorous-computer-science",
-          "format": "news_article",
-          "public_timestamp": "2012-01-11T01:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/harmful-ict-curriculum-set-to-be-dropped-to-make-way-for-rigorous-computer-science",
+          "_id": "/government/publications/reception-baseline-comparability-study",
           "document_type": "edition"
         },
         {
@@ -4439,15 +4333,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Overwhelming support for foreign languages plan",
-          "description": "News on the reaction to the Department for Education’s proposal to make foreign languages compulsory for pupils aged 7 to 11.",
-          "link": "/government/news/overwhelming-support-for-foreign-languages-plan",
-          "format": "news_article",
-          "public_timestamp": "2012-11-17T00:00:00.000+00:00",
-          "index": "government",
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 6: Test administration",
+          "description": "About the testing window, keeping materials secure, the headteacher's declaration form (HDF) and reporting results ",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-6-test-administration",
+          "format": "manual_section",
+          "index": "mainstream",
           "es_score": null,
-          "_id": "/government/news/overwhelming-support-for-foreign-languages-plan",
-          "document_type": "edition"
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-6-test-administration",
+          "document_type": "manual_section"
         },
         {
           "title": "Helping pupils excel at, and enjoy, mathematics",
@@ -4461,56 +4354,77 @@
           "document_type": "edition"
         },
         {
-          "title": "Modern languages: achievement and challenge 2007 to 2010",
-          "description": "Ofsted survey report evaluating language provision in schools and examining current challenges.",
-          "link": "/government/publications/modern-languages-achievement-and-challenge-2007-to-2010",
-          "format": "publication",
-          "public_timestamp": "2011-01-11T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/modern-languages-achievement-and-challenge-2007-to-2010",
-          "document_type": "edition"
-        },
-        {
-          "title": "Reading: supporting higher standards in schools",
-          "description": "How the government will support schools to improve reading standards, and promote reading for pleasure.",
-          "link": "/government/publications/reading-supporting-higher-standards-in-schools",
-          "format": "publication",
-          "public_timestamp": "2015-03-05T00:15:12.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/reading-supporting-higher-standards-in-schools",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 10: Keeping and maintaining records",
-          "description": "Information on disclosure of educational records and transferring records to a pupil's new school",
-          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records",
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 6: Test administration",
+          "description": "About the testing window, keeping materials secure, the headteacher's declaration form (HDF) and reporting results ",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-6-test-administration",
           "format": "manual_section",
           "index": "mainstream",
           "es_score": null,
-          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records",
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-6-test-administration",
           "document_type": "manual_section"
         },
         {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 1: Introduction",
-          "description": "About the 2016 key stage ARA and how to use the new manuals format",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "title": "Closing the gap with the new primary national curriculum",
+          "description": "This project investigated how the best schools continue to close the gap as they implement the new primary national curriculum.",
+          "link": "/government/publications/closing-the-gap-with-the-new-primary-national-curriculum",
+          "format": "publication",
+          "public_timestamp": "2014-09-01T12:24:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/closing-the-gap-with-the-new-primary-national-curriculum",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 5: Participation in tests",
+          "description": "How different types of schools participate in the tests, which pupils should take them and details of access arrangements ",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-5-participation-in-tests",
           "format": "manual_section",
           "index": "mainstream",
           "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-5-participation-in-tests",
           "document_type": "manual_section"
         },
         {
-          "title": "Key stage 2 tests: how to apply for a timetable variation",
-          "description": "Information about how teachers can reschedule the key stage 2 tests. ",
-          "link": "/guidance/key-stage-2-tests-how-to-apply-for-a-timetable-variation",
+          "title": "Key stage 1 and 2: maladministration investigation visits",
+          "description": "Guidance for local authorities about how to carry out a school visit, as part of STA’s investigations in relation to maladministration.",
+          "link": "/guidance/key-stage-1-and-2-school-visits-following-an-allegation-of-maladministration",
           "format": "detailed_guidance",
-          "public_timestamp": "2016-02-12T17:40:44.000+00:00",
+          "public_timestamp": "2016-04-29T16:07:30.000+01:00",
           "index": "detailed",
           "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-a-timetable-variation",
+          "_id": "/guidance/key-stage-1-and-2-school-visits-following-an-allegation-of-maladministration",
+          "document_type": "edition"
+        },
+        {
+          "title": "New primary school tests will help eradicate illiteracy and innumeracy",
+          "description": "Sample questions for the tests taken by 7-year-olds and 11-year-olds show the higher standards expected for reading, writing and arithmetic.",
+          "link": "/government/news/new-primary-school-tests-will-help-eradicate-illiteracy-and-innumeracy",
+          "format": "news_article",
+          "public_timestamp": "2014-07-14T16:45:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/new-primary-school-tests-will-help-eradicate-illiteracy-and-innumeracy",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 13: Legal requirements and responsibilities",
+          "description": "Includes information about the legal status of ARA, the application of the ARA to different types of school and headteachers' responsibilities",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-13-legal-requirements-and-responsibilities",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-13-legal-requirements-and-responsibilities",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "Primary schools’ test results released",
+          "description": "The results of more than 16,000 schools’ key stage 2 tests – taken by 11-year-olds this May – were published today.",
+          "link": "/government/news/primary-schools-test-results-released--2",
+          "format": "news_article",
+          "public_timestamp": "2011-12-15T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/primary-schools-test-results-released--2",
           "document_type": "edition"
         },
         {
@@ -4525,6 +4439,60 @@
           "document_type": "edition"
         },
         {
+          "title": "‘Harmful’ ICT curriculum set to be dropped to make way for rigorous computer science",
+          "description": "Gove announces the scrapping the existing ICT curriculum to introduce new courses of study in computer science.",
+          "link": "/government/news/harmful-ict-curriculum-set-to-be-dropped-to-make-way-for-rigorous-computer-science",
+          "format": "news_article",
+          "public_timestamp": "2012-01-11T01:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/harmful-ict-curriculum-set-to-be-dropped-to-make-way-for-rigorous-computer-science",
+          "document_type": "edition"
+        },
+        {
+          "title": "Overwhelming support for foreign languages plan",
+          "description": "News on the reaction to the Department for Education’s proposal to make foreign languages compulsory for pupils aged 7 to 11.",
+          "link": "/government/news/overwhelming-support-for-foreign-languages-plan",
+          "format": "news_article",
+          "public_timestamp": "2012-11-17T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/overwhelming-support-for-foreign-languages-plan",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 (KS2) testing review reports",
+          "description": "Documents on the key stage 2 (KS2) testing review.",
+          "link": "/government/collections/key-stage-2-ks2-testing-review",
+          "format": "document_collection",
+          "public_timestamp": "2011-06-23T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/collections/key-stage-2-ks2-testing-review",
+          "document_type": "edition"
+        },
+        {
+          "title": "Modern languages: achievement and challenge 2007 to 2010",
+          "description": "Ofsted survey report evaluating language provision in schools and examining current challenges.",
+          "link": "/government/publications/modern-languages-achievement-and-challenge-2007-to-2010",
+          "format": "publication",
+          "public_timestamp": "2011-01-11T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/modern-languages-achievement-and-challenge-2007-to-2010",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 1: Introduction",
+          "description": "About the 2016 key stage ARA and how to use the new manuals format",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-1-introduction",
+          "document_type": "manual_section"
+        },
+        {
           "title": "Use of calculators in primary schools to be reviewed",
           "description": "Schools Minister Nick Gibb has said the use of calculators in primary schools would be looked at as part of the national curriculum review.",
           "link": "/government/news/use-of-calculators-in-primary-schools-to-be-reviewed",
@@ -4536,25 +4504,35 @@
           "document_type": "edition"
         },
         {
-          "title": "Teaching reading in a sample of Stoke-on-Trent primary schools",
-          "description": "How a sample of primary schools in Stoke-on-Trent teach pupils to read.",
-          "link": "/government/publications/ready-to-read-how-a-sample-of-primary-schools-in-stoke-on-trent-teach-pupils-to-read",
-          "format": "publication",
-          "public_timestamp": "2014-06-26T01:00:00.000+01:00",
-          "index": "government",
+          "title": "National curriculum assessments: reporting maladministration",
+          "description": "Information for teachers, LAs and parents with concerns about how schools have carried out national curriculum assessments. ",
+          "link": "/guidance/national-curriculum-assessments-reporting-maladministration",
+          "format": "detailed_guidance",
+          "public_timestamp": "2014-04-16T00:00:00.000+01:00",
+          "index": "detailed",
           "es_score": null,
-          "_id": "/government/publications/ready-to-read-how-a-sample-of-primary-schools-in-stoke-on-trent-teach-pupils-to-read",
+          "_id": "/guidance/national-curriculum-assessments-reporting-maladministration",
           "document_type": "edition"
         },
         {
-          "title": "2016 key stage 1 mathematics test: sample questions, mark scheme and commentary",
+          "title": "2016 Key stage 1: assessment and reporting arrangements (ARA): Section 10: Keeping and maintaining records",
+          "description": "Information on disclosure of educational records and transferring records to a pupil's new school",
+          "link": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "2016 key stage 1 English grammar, punctuation and spelling test: sample questions, mark scheme and commentary",
           "description": "Information to help teachers prepare for the new tests of the new national curriculum. ",
-          "link": "/government/publications/2016-key-stage-1-mathematics-test-sample-questions-mark-scheme-and-commentary",
+          "link": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary",
           "format": "publication",
-          "public_timestamp": "2014-07-14T09:45:00.000+01:00",
+          "public_timestamp": "2014-07-14T17:01:07.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/2016-key-stage-1-mathematics-test-sample-questions-mark-scheme-and-commentary",
+          "_id": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary",
           "document_type": "edition"
         },
         {
@@ -4580,69 +4558,80 @@
           "document_type": "edition"
         },
         {
-          "title": "Using modern technology to improve English",
-          "description": "Ofsted good practice example showing how Alwoodley Primary School uses information and communication technology to improve English.",
-          "link": "/government/publications/using-modern-technology-to-improve-english",
-          "format": "publication",
-          "public_timestamp": "2013-01-16T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/using-modern-technology-to-improve-english",
-          "document_type": "edition"
-        },
-        {
-          "title": "National curriculum assessments: reporting maladministration",
-          "description": "Information for teachers, LAs and parents with concerns about how schools have carried out national curriculum assessments. ",
-          "link": "/guidance/national-curriculum-assessments-reporting-maladministration",
+          "title": "Key stage 2 tests: how to apply for a timetable variation",
+          "description": "Information about how teachers can reschedule the key stage 2 tests. ",
+          "link": "/guidance/key-stage-2-tests-how-to-apply-for-a-timetable-variation",
           "format": "detailed_guidance",
-          "public_timestamp": "2014-04-16T00:00:00.000+01:00",
+          "public_timestamp": "2016-02-12T17:40:44.000+00:00",
           "index": "detailed",
           "es_score": null,
-          "_id": "/guidance/national-curriculum-assessments-reporting-maladministration",
+          "_id": "/guidance/key-stage-2-tests-how-to-apply-for-a-timetable-variation",
           "document_type": "edition"
         },
         {
-          "title": "Meeting technological challenges: school design and technology provision",
-          "description": "Ofsted survey report evaluating the provision of design and technology in the curriculum.",
-          "link": "/government/publications/meeting-technological-challenges-school-design-and-technology-provision",
+          "title": "Teaching reading in a sample of Stoke-on-Trent primary schools",
+          "description": "How a sample of primary schools in Stoke-on-Trent teach pupils to read.",
+          "link": "/government/publications/ready-to-read-how-a-sample-of-primary-schools-in-stoke-on-trent-teach-pupils-to-read",
           "format": "publication",
-          "public_timestamp": "2011-03-25T00:00:00.000+00:00",
+          "public_timestamp": "2014-06-26T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/meeting-technological-challenges-school-design-and-technology-provision",
+          "_id": "/government/publications/ready-to-read-how-a-sample-of-primary-schools-in-stoke-on-trent-teach-pupils-to-read",
           "document_type": "edition"
         },
         {
-          "title": "2016 key stage 1 English grammar, punctuation and spelling test: sample questions, mark scheme and commentary",
+          "title": "Developing a relevant curriculum",
+          "description": "Ofsted good practice example showing how Good Shepherd Catholic Primary School refocused its curriculum to prepare pupils for the future.",
+          "link": "/government/publications/developing-a-relevant-curriculum",
+          "format": "publication",
+          "public_timestamp": "2013-04-09T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/developing-a-relevant-curriculum",
+          "document_type": "edition"
+        },
+        {
+          "title": "Thousands of pupils to visit First World War battlefields",
+          "description": "More than 1,000 schools have already signed up to give their pupils the chance to visit the First World War battlefields.",
+          "link": "/government/news/thousands-of-pupils-to-visit-first-world-war-battlefields",
+          "format": "news_article",
+          "public_timestamp": "2013-10-21T10:34:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/thousands-of-pupils-to-visit-first-world-war-battlefields",
+          "document_type": "edition"
+        },
+        {
+          "title": "Elite teachers travel from Shanghai for pioneering maths exchange",
+          "description": "Chinese maths teachers will spend time in English primary schools to share their teaching methods as part of the teacher-led exchange.",
+          "link": "/government/news/elite-teachers-travel-from-shanghai-for-pioneering-maths-exchange",
+          "format": "news_article",
+          "public_timestamp": "2014-11-04T11:35:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/elite-teachers-travel-from-shanghai-for-pioneering-maths-exchange",
+          "document_type": "edition"
+        },
+        {
+          "title": "2016 key stage 1 mathematics test: sample questions, mark scheme and commentary",
           "description": "Information to help teachers prepare for the new tests of the new national curriculum. ",
-          "link": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary",
+          "link": "/government/publications/2016-key-stage-1-mathematics-test-sample-questions-mark-scheme-and-commentary",
           "format": "publication",
-          "public_timestamp": "2014-07-14T17:01:07.000+01:00",
+          "public_timestamp": "2014-07-14T09:45:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary",
+          "_id": "/government/publications/2016-key-stage-1-mathematics-test-sample-questions-mark-scheme-and-commentary",
           "document_type": "edition"
         },
         {
-          "title": "Introduction of statutory participation in trialling of national curriculum tests from 2016",
-          "description": "Information about the requirement of selected schools to participate in statutory national curriculum test trials from 2016",
-          "link": "/guidance/introduction-of-statutory-participation-in-trialling-of-national-curriculum-tests-from-2016",
-          "format": "detailed_guidance",
-          "public_timestamp": "2015-09-29T10:15:12.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/introduction-of-statutory-participation-in-trialling-of-national-curriculum-tests-from-2016",
-          "document_type": "edition"
-        },
-        {
-          "title": "Nicky Morgan: improving child literacy in England",
-          "description": "The Secretary of State for Education on her new literacy campaign aiming to make children in England the best in Europe at reading.",
-          "link": "/government/speeches/nicky-morgan-improving-child-literacy-in-england",
-          "format": "speech",
-          "public_timestamp": "2015-09-24T11:00:04.000+01:00",
+          "title": "Assessment updates for schools",
+          "description": "Information about the Standards and Testing Agency's email newsletters for early years providers and key stage 1 and key stage 2 schools.",
+          "link": "/government/news/assessment-updates-for-schools",
+          "format": "news_article",
+          "public_timestamp": "2015-03-19T11:40:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/nicky-morgan-improving-child-literacy-in-england",
+          "_id": "/government/news/assessment-updates-for-schools",
           "document_type": "edition"
         },
         {
@@ -4657,6 +4646,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Using modern technology to improve English",
+          "description": "Ofsted good practice example showing how Alwoodley Primary School uses information and communication technology to improve English.",
+          "link": "/government/publications/using-modern-technology-to-improve-english",
+          "format": "publication",
+          "public_timestamp": "2013-01-16T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/using-modern-technology-to-improve-english",
+          "document_type": "edition"
+        },
+        {
           "title": "Improving science with the Lab 13 project",
           "description": "Ofsted good practice example showing how Irchester Community Primary School has improved science as part of a whole-school journey to good.",
           "link": "/government/publications/improving-science-with-the-lab-13-project",
@@ -4668,14 +4668,69 @@
           "document_type": "edition"
         },
         {
-          "title": "Elite teachers travel from Shanghai for pioneering maths exchange",
-          "description": "Chinese maths teachers will spend time in English primary schools to share their teaching methods as part of the teacher-led exchange.",
-          "link": "/government/news/elite-teachers-travel-from-shanghai-for-pioneering-maths-exchange",
-          "format": "news_article",
-          "public_timestamp": "2014-11-04T11:35:00.000+00:00",
+          "title": "Meeting technological challenges: school design and technology provision",
+          "description": "Ofsted survey report evaluating the provision of design and technology in the curriculum.",
+          "link": "/government/publications/meeting-technological-challenges-school-design-and-technology-provision",
+          "format": "publication",
+          "public_timestamp": "2011-03-25T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/elite-teachers-travel-from-shanghai-for-pioneering-maths-exchange",
+          "_id": "/government/publications/meeting-technological-challenges-school-design-and-technology-provision",
+          "document_type": "edition"
+        },
+        {
+          "title": "Independent review of key stage 2 testing, assessment and accountability: final report",
+          "description": "Lord Bew’s final report into key stage 2 testing, assessment and accountability.",
+          "link": "/government/publications/independent-review-of-key-stage-2-testing-assessment-and-accountability-final-report",
+          "format": "publication",
+          "public_timestamp": "2011-06-23T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/independent-review-of-key-stage-2-testing-assessment-and-accountability-final-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 tests: oral statement",
+          "description": "Schools Minister Nick Gibb’s oral statement on the key stage 2 English grammar, punctuation and spelling test. ",
+          "link": "/government/speeches/oral-statement-on-key-stage-2-tests",
+          "format": "speech",
+          "public_timestamp": "2016-05-10T12:59:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/oral-statement-on-key-stage-2-tests",
+          "document_type": "edition"
+        },
+        {
+          "title": "Nicky Morgan: improving child literacy in England",
+          "description": "The Secretary of State for Education on her new literacy campaign aiming to make children in England the best in Europe at reading.",
+          "link": "/government/speeches/nicky-morgan-improving-child-literacy-in-england",
+          "format": "speech",
+          "public_timestamp": "2015-09-24T11:00:04.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/nicky-morgan-improving-child-literacy-in-england",
+          "document_type": "edition"
+        },
+        {
+          "title": "New primary curriculum to bring higher standards in English, maths and science",
+          "description": "Details of changes to the primary national curriculum. ",
+          "link": "/government/news/new-primary-curriculum-to-bring-higher-standards-in-english-maths-and-science",
+          "format": "news_article",
+          "public_timestamp": "2012-06-11T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/new-primary-curriculum-to-bring-higher-standards-in-english-maths-and-science",
+          "document_type": "edition"
+        },
+        {
+          "title": "Reading: supporting higher standards in schools",
+          "description": "How the government will support schools to improve reading standards, and promote reading for pleasure.",
+          "link": "/government/publications/reading-supporting-higher-standards-in-schools",
+          "format": "publication",
+          "public_timestamp": "2015-03-05T00:15:12.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/reading-supporting-higher-standards-in-schools",
           "document_type": "edition"
         },
         {
@@ -4701,47 +4756,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Developing a relevant curriculum",
-          "description": "Ofsted good practice example showing how Good Shepherd Catholic Primary School refocused its curriculum to prepare pupils for the future.",
-          "link": "/government/publications/developing-a-relevant-curriculum",
+          "title": "Key stage 2 tests: demonstrate correct test administration",
+          "description": "Advice for headteachers on how to avoid allegations of maladministration during the key stage 2 national curriculum tests.",
+          "link": "/government/publications/key-stage-2-tests-demonstrate-correct-test-administration",
           "format": "publication",
-          "public_timestamp": "2013-04-09T01:00:00.000+01:00",
+          "public_timestamp": "2016-03-31T18:52:58.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/developing-a-relevant-curriculum",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: oral statement",
-          "description": "Schools Minister Nick Gibb’s oral statement on the key stage 2 English grammar, punctuation and spelling test. ",
-          "link": "/government/speeches/oral-statement-on-key-stage-2-tests",
-          "format": "speech",
-          "public_timestamp": "2016-05-10T12:59:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/oral-statement-on-key-stage-2-tests",
-          "document_type": "edition"
-        },
-        {
-          "title": "Thousands of pupils to visit First World War battlefields",
-          "description": "More than 1,000 schools have already signed up to give their pupils the chance to visit the First World War battlefields.",
-          "link": "/government/news/thousands-of-pupils-to-visit-first-world-war-battlefields",
-          "format": "news_article",
-          "public_timestamp": "2013-10-21T10:34:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/thousands-of-pupils-to-visit-first-world-war-battlefields",
-          "document_type": "edition"
-        },
-        {
-          "title": "Languages at the heart of the curriculum",
-          "description": "Ofsted good practice example showing how Springfield Lower pupils make rapid progress in Italian.",
-          "link": "/government/publications/languages-at-the-heart-of-the-curriculum",
-          "format": "publication",
-          "public_timestamp": "2013-10-24T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/languages-at-the-heart-of-the-curriculum",
+          "_id": "/government/publications/key-stage-2-tests-demonstrate-correct-test-administration",
           "document_type": "edition"
         },
         {
@@ -4756,58 +4778,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Independent review of key stage 2 testing, assessment and accountability: final report",
-          "description": "Lord Bew’s final report into key stage 2 testing, assessment and accountability.",
-          "link": "/government/publications/independent-review-of-key-stage-2-testing-assessment-and-accountability-final-report",
+          "title": "Languages at the heart of the curriculum",
+          "description": "Ofsted good practice example showing how Springfield Lower pupils make rapid progress in Italian.",
+          "link": "/government/publications/languages-at-the-heart-of-the-curriculum",
           "format": "publication",
-          "public_timestamp": "2011-06-23T01:00:00.000+01:00",
+          "public_timestamp": "2013-10-24T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/independent-review-of-key-stage-2-testing-assessment-and-accountability-final-report",
-          "document_type": "edition"
-        },
-        {
-          "title": "Assessment updates for schools",
-          "description": "Information about the Standards and Testing Agency's email newsletters for early years providers and key stage 1 and key stage 2 schools.",
-          "link": "/government/news/assessment-updates-for-schools",
-          "format": "news_article",
-          "public_timestamp": "2015-03-19T11:40:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/assessment-updates-for-schools",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 test results published",
-          "description": "Nick Gibb: Improvement welcome – but more needs to be done.\r\n",
-          "link": "/government/news/key-stage-2-test-results-published--2",
-          "format": "news_article",
-          "public_timestamp": "2011-08-02T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/key-stage-2-test-results-published--2",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: demonstrate correct test administration",
-          "description": "Advice for headteachers on how to avoid allegations of maladministration during the key stage 2 national curriculum tests.",
-          "link": "/government/publications/key-stage-2-tests-demonstrate-correct-test-administration",
-          "format": "publication",
-          "public_timestamp": "2016-03-31T18:52:58.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-tests-demonstrate-correct-test-administration",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 science sampling 2014: methodological note and outcomes",
-          "description": "This document provides information on the outcomes of the key stage 2 (KS2) science sampling assessment in 2014 and explains the new sampling methodology",
-          "link": "/government/publications/key-stage-2-science-sampling-2014-methodological-note-and-outcomes",
-          "format": "publication",
-          "public_timestamp": "2016-01-28T09:30:29.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-science-sampling-2014-methodological-note-and-outcomes",
+          "_id": "/government/publications/languages-at-the-heart-of-the-curriculum",
           "document_type": "edition"
         },
         {
@@ -4822,6 +4800,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Introduction of statutory participation in trialling of national curriculum tests from 2016",
+          "description": "Information about the requirement of selected schools to participate in statutory national curriculum test trials from 2016",
+          "link": "/guidance/introduction-of-statutory-participation-in-trialling-of-national-curriculum-tests-from-2016",
+          "format": "detailed_guidance",
+          "public_timestamp": "2015-09-29T10:15:12.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/introduction-of-statutory-participation-in-trialling-of-national-curriculum-tests-from-2016",
+          "document_type": "edition"
+        },
+        {
           "title": "Factors associated with achievement: key stages 2 and 4",
           "description": "Research looking at different measures of socio-economic deprivation and their usefulness for providing funding to schools.",
           "link": "/government/publications/factors-associated-with-achievement-key-stages-2-and-4",
@@ -4830,27 +4819,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/factors-associated-with-achievement-key-stages-2-and-4",
-          "document_type": "edition"
-        },
-        {
-          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 7: Monitoring the tests",
-          "description": "Information on monitoring the tests including maladministration",
-          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-7-monitoring-the-tests",
-          "format": "manual_section",
-          "index": "mainstream",
-          "es_score": null,
-          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-7-monitoring-the-tests",
-          "document_type": "manual_section"
-        },
-        {
-          "title": "90,000 more pupils leaving primary with maths and literacy skills",
-          "description": "Key stage 2 results show substantial increases in the number of 11-year-olds securing skills needed for secondary school compared to 2010.",
-          "link": "/government/news/90000-more-pupils-leaving-primary-with-maths-and-literacy-skills",
-          "format": "news_article",
-          "public_timestamp": "2015-08-27T10:25:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/90000-more-pupils-leaving-primary-with-maths-and-literacy-skills",
           "document_type": "edition"
         },
         {
@@ -4865,6 +4833,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Key stage 2 science sampling 2014: methodological note and outcomes",
+          "description": "This document provides information on the outcomes of the key stage 2 (KS2) science sampling assessment in 2014 and explains the new sampling methodology",
+          "link": "/government/publications/key-stage-2-science-sampling-2014-methodological-note-and-outcomes",
+          "format": "publication",
+          "public_timestamp": "2016-01-28T09:30:29.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-science-sampling-2014-methodological-note-and-outcomes",
+          "document_type": "edition"
+        },
+        {
           "title": "Key stage 2 teacher assessment data collection 2016: technical specification",
           "description": "Technical specification for software suppliers, educators and local authorities completing returns for the key stage 2 data collection 2016.",
           "link": "/government/publications/key-stage-2-teacher-assessment-data-collection-2016-technical-specification",
@@ -4873,83 +4852,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/key-stage-2-teacher-assessment-data-collection-2016-technical-specification",
-          "document_type": "edition"
-        },
-        {
-          "title": "Primary schools’ test results released",
-          "description": "News on a bid to improve standards in primary schools.",
-          "link": "/government/news/primary-schools-test-results-released",
-          "format": "news_article",
-          "public_timestamp": "2012-12-13T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/primary-schools-test-results-released",
-          "document_type": "edition"
-        },
-        {
-          "title": "New primary curriculum to bring higher standards in English, maths and science",
-          "description": "Details of changes to the primary national curriculum. ",
-          "link": "/government/news/new-primary-curriculum-to-bring-higher-standards-in-english-maths-and-science",
-          "format": "news_article",
-          "public_timestamp": "2012-06-11T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/new-primary-curriculum-to-bring-higher-standards-in-english-maths-and-science",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: how to carry out a monitoring visit",
-          "description": "Instructions for local authority monitoring visitors, including the monitoring visits form.",
-          "link": "/guidance/key-stage-2-tests-how-to-carry-out-a-monitoring-visit",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-04-11T16:19:14.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-how-to-carry-out-a-monitoring-visit",
-          "document_type": "edition"
-        },
-        {
-          "title": "Classification accuracy in key stage 2 test results",
-          "description": "Research into the reliability of level classifications in the key stage 2 science, maths and English tests taken in 2009 and 2010.",
-          "link": "/government/publications/classification-accuracy-in-key-stage-2-test-results",
-          "format": "publication",
-          "public_timestamp": "2013-05-16T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/classification-accuracy-in-key-stage-2-test-results",
-          "document_type": "edition"
-        },
-        {
-          "title": "Developing a communication supporting classrooms observation tool",
-          "description": "This study aimed to develop a tool for Reception and key stage 1, pilot its feasibility in classrooms and examine its use by practitioners.",
-          "link": "/government/publications/developing-a-communication-supporting-classrooms-observation-tool",
-          "format": "publication",
-          "public_timestamp": "2012-12-27T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/developing-a-communication-supporting-classrooms-observation-tool",
-          "document_type": "edition"
-        },
-        {
-          "title": "Attendance register and test script dispatch",
-          "description": "Instructions for completing attendance registers for the key stage 2 tests, and sending test scripts for marking.",
-          "link": "/government/publications/key-stage-2-attendance-register-and-test-script-dispatch",
-          "format": "publication",
-          "public_timestamp": "2016-03-31T18:52:37.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-attendance-register-and-test-script-dispatch",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 tests: what to do if a pupil cheats",
-          "description": "Information for headteachers about the action to be taken if a pupil is caught cheating during the key stage 2 national curriculum tests.",
-          "link": "/guidance/key-stage-2-tests-what-to-do-if-a-child-cheats",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-05-09T16:34:30.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/key-stage-2-tests-what-to-do-if-a-child-cheats",
           "document_type": "edition"
         },
         {
@@ -4964,69 +4866,58 @@
           "document_type": "edition"
         },
         {
-          "title": "Investigation of key stage 2 level 6 tests",
-          "description": "Findings from a study into how the level 6 tests have affected the way schools support their most able pupils.",
-          "link": "/government/publications/investigation-of-key-stage-2-level-6-tests",
-          "format": "publication",
-          "public_timestamp": "2013-04-02T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/investigation-of-key-stage-2-level-6-tests",
-          "document_type": "edition"
-        },
-        {
-          "title": "2014 Maladministration report",
-          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2014 test cycle",
-          "link": "/government/publications/2014-maladministration-report",
-          "format": "publication",
-          "public_timestamp": "2015-12-17T07:38:17.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2014-maladministration-report",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 test results published",
-          "description": "Find out the results of tests in reading, writing and maths at the end of primary school in summer 2012.",
-          "link": "/government/news/key-stage-2-test-results-published",
+          "title": "90,000 more pupils leaving primary with maths and literacy skills",
+          "description": "Key stage 2 results show substantial increases in the number of 11-year-olds securing skills needed for secondary school compared to 2010.",
+          "link": "/government/news/90000-more-pupils-leaving-primary-with-maths-and-literacy-skills",
           "format": "news_article",
-          "public_timestamp": "2012-09-20T01:00:00.000+01:00",
+          "public_timestamp": "2015-08-27T10:25:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/key-stage-2-test-results-published",
+          "_id": "/government/news/90000-more-pupils-leaving-primary-with-maths-and-literacy-skills",
           "document_type": "edition"
         },
         {
-          "title": "2016 national curriculum tests – sample materials now available",
-          "description": "Find out more about the new tests for key stage 1 and key stage 2. ",
-          "link": "/government/news/2016-national-curriculum-tests-sample-materials-now-available",
+          "title": "Primary schools’ test results released",
+          "description": "News on a bid to improve standards in primary schools.",
+          "link": "/government/news/primary-schools-test-results-released",
           "format": "news_article",
-          "public_timestamp": "2014-07-14T09:30:00.000+01:00",
+          "public_timestamp": "2012-12-13T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/2016-national-curriculum-tests-sample-materials-now-available",
+          "_id": "/government/news/primary-schools-test-results-released",
           "document_type": "edition"
         },
         {
-          "title": "PIRLS 2011: reading achievement in England - brief",
-          "description": "Findings from the 'Progress in reading and literacy study' (PIRLS), comparing the reading attainment and attitudes of 10-year-olds.",
-          "link": "/government/publications/pirls-2011-reading-achievement-in-england-brief",
+          "title": "Key stage 2 tests: how to carry out a monitoring visit",
+          "description": "Instructions for local authority monitoring visitors, including the monitoring visits form.",
+          "link": "/guidance/key-stage-2-tests-how-to-carry-out-a-monitoring-visit",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-04-11T16:19:14.000+01:00",
+          "index": "detailed",
+          "es_score": null,
+          "_id": "/guidance/key-stage-2-tests-how-to-carry-out-a-monitoring-visit",
+          "document_type": "edition"
+        },
+        {
+          "title": "Developing a communication supporting classrooms observation tool",
+          "description": "This study aimed to develop a tool for Reception and key stage 1, pilot its feasibility in classrooms and examine its use by practitioners.",
+          "link": "/government/publications/developing-a-communication-supporting-classrooms-observation-tool",
           "format": "publication",
-          "public_timestamp": "2012-11-12T00:00:00.000+00:00",
+          "public_timestamp": "2012-12-27T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/pirls-2011-reading-achievement-in-england-brief",
+          "_id": "/government/publications/developing-a-communication-supporting-classrooms-observation-tool",
           "document_type": "edition"
         },
         {
-          "title": "Second phase of pioneering Shanghai maths teacher exchange begins",
-          "description": "Teachers report Shanghai methods are already raising standards in schools that took part in the first phase of exchange.",
-          "link": "/government/news/second-phase-of-pioneering-shanghai-maths-teacher-exchange-begins",
-          "format": "news_article",
-          "public_timestamp": "2015-02-23T15:52:40.000+00:00",
-          "index": "government",
+          "title": "Key stage 2 tests: what to do if a pupil cheats",
+          "description": "Information for headteachers about the action to be taken if a pupil is caught cheating during the key stage 2 national curriculum tests.",
+          "link": "/guidance/key-stage-2-tests-what-to-do-if-a-child-cheats",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-05-09T16:34:30.000+01:00",
+          "index": "detailed",
           "es_score": null,
-          "_id": "/government/news/second-phase-of-pioneering-shanghai-maths-teacher-exchange-begins",
+          "_id": "/guidance/key-stage-2-tests-what-to-do-if-a-child-cheats",
           "document_type": "edition"
         },
         {
@@ -5063,28 +4954,6 @@
           "document_type": "edition"
         },
         {
-          "title": "How do pupils progress during key stages 2 and 3?",
-          "description": "Research exploring data from teacher assessments about pupil progress in reading, writing and maths, and its contributing factors.",
-          "link": "/government/publications/how-do-pupils-progress-during-key-stages-2-and-3",
-          "format": "publication",
-          "public_timestamp": "2011-03-31T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/how-do-pupils-progress-during-key-stages-2-and-3",
-          "document_type": "edition"
-        },
-        {
-          "title": "Introduction of a new methodology for measuring attainment in key stage 2 science sampling",
-          "description": "Information about how attainment in key stage 2 science sampling is measured",
-          "link": "/government/news/introduction-of-a-new-methodology-for-measuring-attainment-in-key-stage-2-science-sampling",
-          "format": "news_article",
-          "public_timestamp": "2016-01-27T15:11:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/introduction-of-a-new-methodology-for-measuring-attainment-in-key-stage-2-science-sampling",
-          "document_type": "edition"
-        },
-        {
           "title": "Key stage 1 assessments collection 2015: guide",
           "description": "How local authorities should complete and return 2015 key stage 1 assessment results to the Department for Education.",
           "link": "/government/publications/key-stage-1-assessments-collection-2015-guide",
@@ -5096,124 +4965,145 @@
           "document_type": "edition"
         },
         {
-          "title": "Nicky Morgan and David Walliams launch literacy drive",
-          "description": "The Education Secretary and children’s author issue a call to publishers and schools to make English pupils Europe’s most literate.",
-          "link": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
-          "format": "news_article",
-          "public_timestamp": "2015-09-24T09:59:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
-          "document_type": "edition"
-        },
-        {
-          "title": "Primary testing and assessment: webinar registration still open",
-          "description": "Register now to join our two interactive webinars about the 2016 national curriculum tests and assessments.\r\n",
-          "link": "/government/news/primary-testing-and-assessment-webinar-registration-still-open",
-          "format": "news_article",
-          "public_timestamp": "2015-11-18T13:28:42.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/primary-testing-and-assessment-webinar-registration-still-open",
-          "document_type": "edition"
-        },
-        {
-          "title": "Eight effective music education partnerships",
-          "description": "Good practice report. How schools can build effective partnerships to improve access and raise achievement in music for all pupils.",
-          "link": "/government/publications/music-in-schools-sound-partnerships-eight-effective-music-education-partnerships",
-          "format": "publication",
-          "public_timestamp": "2012-12-05T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/music-in-schools-sound-partnerships-eight-effective-music-education-partnerships",
-          "document_type": "edition"
-        },
-        {
-          "title": "Ofsted updates School Data Dashboard with 2013 results",
-          "description": "Data for key stages 1 and 2 has been updated.",
-          "link": "/government/news/ofsted-updates-school-data-dashboard-with-2013-results",
-          "format": "news_article",
-          "public_timestamp": "2014-03-07T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/ofsted-updates-school-data-dashboard-with-2013-results",
-          "document_type": "edition"
-        },
-        {
-          "title": "KS1 assessments data collection 2015: technical specification",
-          "description": "Technical specification defining the scope of the 2015 key stage 1 (KS1) assessments data collection from local authorities.",
-          "link": "/government/publications/ks1-assessments-data-collection-2015-technical-specification",
-          "format": "publication",
-          "public_timestamp": "2015-04-17T16:58:21.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/ks1-assessments-data-collection-2015-technical-specification",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 writing moderation: evaluation of the 2011 to 2012 interim arrangements",
-          "description": "This evaluation explored the impact of the 2012 KS2 writing moderation arrangements on a sample of moderation managers, moderators and schools.",
-          "link": "/government/publications/key-stage-2-writing-moderation-evaluation-of-the-20112012-interim-arrangements",
-          "format": "publication",
-          "public_timestamp": "2012-12-17T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-writing-moderation-evaluation-of-the-20112012-interim-arrangements",
-          "document_type": "edition"
-        },
-        {
-          "title": "Investigating reliability in key stage 2 tests",
-          "description": "A study analysing the reliability of key stage 2 science tests. ",
-          "link": "/government/publications/investigating-reliability-in-key-stage-2-tests",
+          "title": "Classification accuracy in key stage 2 test results",
+          "description": "Research into the reliability of level classifications in the key stage 2 science, maths and English tests taken in 2009 and 2010.",
+          "link": "/government/publications/classification-accuracy-in-key-stage-2-test-results",
           "format": "publication",
           "public_timestamp": "2013-05-16T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/investigating-reliability-in-key-stage-2-tests",
+          "_id": "/government/publications/classification-accuracy-in-key-stage-2-test-results",
           "document_type": "edition"
         },
         {
-          "title": "Review of key stage 2 testing, assessment and accountability: progress report",
-          "description": "This progress report outlines the evidence and ranges of opinion on key stage 2 testing, but does not include any recommendations.",
-          "link": "/government/publications/review-of-key-stage-2-testing-assessment-and-accountability-progress-report",
+          "title": "2016 Key stage 2: assessment and reporting arrangements (ARA): Section 7: Monitoring the tests",
+          "description": "Information on monitoring the tests including maladministration",
+          "link": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-7-monitoring-the-tests",
+          "format": "manual_section",
+          "index": "mainstream",
+          "es_score": null,
+          "_id": "/guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-7-monitoring-the-tests",
+          "document_type": "manual_section"
+        },
+        {
+          "title": "Investigation of key stage 2 level 6 tests",
+          "description": "Findings from a study into how the level 6 tests have affected the way schools support their most able pupils.",
+          "link": "/government/publications/investigation-of-key-stage-2-level-6-tests",
           "format": "publication",
-          "public_timestamp": "2011-04-07T01:00:00.000+01:00",
+          "public_timestamp": "2013-04-02T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/review-of-key-stage-2-testing-assessment-and-accountability-progress-report",
+          "_id": "/government/publications/investigation-of-key-stage-2-level-6-tests",
           "document_type": "edition"
         },
         {
-          "title": "Primary test results: standards rising in all subjects",
-          "description": "Eighty thousand more children than 5 years ago will start secondary school secure in reading, writing and arithmetic.",
-          "link": "/government/news/primary-test-results-standards-rising-in-all-subjects",
-          "format": "news_article",
-          "public_timestamp": "2014-08-28T12:20:01.000+01:00",
+          "title": "2014 Maladministration report",
+          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2014 test cycle",
+          "link": "/government/publications/2014-maladministration-report",
+          "format": "publication",
+          "public_timestamp": "2015-12-17T07:38:17.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/primary-test-results-standards-rising-in-all-subjects",
+          "_id": "/government/publications/2014-maladministration-report",
           "document_type": "edition"
         },
         {
-          "title": "Register now for primary assessment webinars",
-          "description": "Register to join two interactive webinars about the 2016 national curriculum tests and assessments",
-          "link": "/government/news/register-now-for-primary-assessment-webinars",
+          "title": "2016 national curriculum tests – sample materials now available",
+          "description": "Find out more about the new tests for key stage 1 and key stage 2. ",
+          "link": "/government/news/2016-national-curriculum-tests-sample-materials-now-available",
           "format": "news_article",
-          "public_timestamp": "2016-02-18T15:03:08.000+00:00",
+          "public_timestamp": "2014-07-14T09:30:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/register-now-for-primary-assessment-webinars",
+          "_id": "/government/news/2016-national-curriculum-tests-sample-materials-now-available",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2 pupil achievement figures",
-          "description": "Statistics on 2010 national curriculum assessments at key stage 2 in England, and a statement from Michael Gove.",
-          "link": "/government/news/key-stage-2-pupil-achievement-figures",
-          "format": "news_article",
-          "public_timestamp": "2010-12-17T00:00:00.000+00:00",
+          "title": "PIRLS 2011: reading achievement in England - brief",
+          "description": "Findings from the 'Progress in reading and literacy study' (PIRLS), comparing the reading attainment and attitudes of 10-year-olds.",
+          "link": "/government/publications/pirls-2011-reading-achievement-in-england-brief",
+          "format": "publication",
+          "public_timestamp": "2012-11-12T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/key-stage-2-pupil-achievement-figures",
+          "_id": "/government/publications/pirls-2011-reading-achievement-in-england-brief",
+          "document_type": "edition"
+        },
+        {
+          "title": "Second phase of pioneering Shanghai maths teacher exchange begins",
+          "description": "Teachers report Shanghai methods are already raising standards in schools that took part in the first phase of exchange.",
+          "link": "/government/news/second-phase-of-pioneering-shanghai-maths-teacher-exchange-begins",
+          "format": "news_article",
+          "public_timestamp": "2015-02-23T15:52:40.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/second-phase-of-pioneering-shanghai-maths-teacher-exchange-begins",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 test results published",
+          "description": "Nick Gibb: Improvement welcome – but more needs to be done.\r\n",
+          "link": "/government/news/key-stage-2-test-results-published--2",
+          "format": "news_article",
+          "public_timestamp": "2011-08-02T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/key-stage-2-test-results-published--2",
+          "document_type": "edition"
+        },
+        {
+          "title": "How do pupils progress during key stages 2 and 3?",
+          "description": "Research exploring data from teacher assessments about pupil progress in reading, writing and maths, and its contributing factors.",
+          "link": "/government/publications/how-do-pupils-progress-during-key-stages-2-and-3",
+          "format": "publication",
+          "public_timestamp": "2011-03-31T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/how-do-pupils-progress-during-key-stages-2-and-3",
+          "document_type": "edition"
+        },
+        {
+          "title": "2012 maladministration report",
+          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2012 test cycle.",
+          "link": "/government/publications/2012-maladministration-report",
+          "format": "publication",
+          "public_timestamp": "2013-08-22T10:23:38.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2012-maladministration-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1 assessments data collection: closed collections",
+          "description": "Documents for software suppliers and anyone else interested in past key stage 1 (KS1) assessments data collections.",
+          "link": "/government/collections/key-stage-1-assessments-data-collection",
+          "format": "document_collection",
+          "public_timestamp": "2016-02-12T17:12:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/collections/key-stage-1-assessments-data-collection",
+          "document_type": "edition"
+        },
+        {
+          "title": "Cost of administering SATs in primary school",
+          "description": "Total breakdown of cost of administering standard attainment tests (SATs) for key stages 1 and 2 for the most recent financial year.",
+          "link": "/government/publications/cost-of-administering-sats-in-primary-school",
+          "format": "publication",
+          "public_timestamp": "2014-08-15T10:34:58.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/cost-of-administering-sats-in-primary-school",
+          "document_type": "edition"
+        },
+        {
+          "title": "2012 maladministration investigation procedures",
+          "description": "The purpose of this document is to outline procedures followed by STA when investigating allegations of maladministration.",
+          "link": "/government/publications/2012-maladministration-investigation-procedures",
+          "format": "publication",
+          "public_timestamp": "2012-10-01T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2012-maladministration-investigation-procedures",
           "document_type": "edition"
         },
         {
@@ -5228,14 +5118,201 @@
           "document_type": "edition"
         },
         {
-          "title": "2012 maladministration report",
-          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2012 test cycle.",
-          "link": "/government/publications/2012-maladministration-report",
-          "format": "publication",
-          "public_timestamp": "2013-08-22T10:23:38.000+01:00",
+          "title": "Primary testing and assessment: webinar registration still open",
+          "description": "Register now to join our two interactive webinars about the 2016 national curriculum tests and assessments.\r\n",
+          "link": "/government/news/primary-testing-and-assessment-webinar-registration-still-open",
+          "format": "news_article",
+          "public_timestamp": "2015-11-18T13:28:42.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/2012-maladministration-report",
+          "_id": "/government/news/primary-testing-and-assessment-webinar-registration-still-open",
+          "document_type": "edition"
+        },
+        {
+          "title": "English grammar, punctuation and spelling: 2013 technical report",
+          "description": "This report provides an analysis of the key stage 2 English grammar, punctuation and spelling test.",
+          "link": "/government/publications/english-grammar-punctuation-and-spelling-2013-technical-report",
+          "format": "publication",
+          "public_timestamp": "2015-05-29T13:55:58.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/english-grammar-punctuation-and-spelling-2013-technical-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "Eight effective music education partnerships",
+          "description": "Good practice report. How schools can build effective partnerships to improve access and raise achievement in music for all pupils.",
+          "link": "/government/publications/music-in-schools-sound-partnerships-eight-effective-music-education-partnerships",
+          "format": "publication",
+          "public_timestamp": "2012-12-05T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/music-in-schools-sound-partnerships-eight-effective-music-education-partnerships",
+          "document_type": "edition"
+        },
+        {
+          "title": "Review of key stage 2 testing, assessment and accountability: progress report",
+          "description": "This progress report outlines the evidence and ranges of opinion on key stage 2 testing, but does not include any recommendations.",
+          "link": "/government/publications/review-of-key-stage-2-testing-assessment-and-accountability-progress-report",
+          "format": "publication",
+          "public_timestamp": "2011-04-07T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/review-of-key-stage-2-testing-assessment-and-accountability-progress-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 test results published",
+          "description": "Find out the results of tests in reading, writing and maths at the end of primary school in summer 2012.",
+          "link": "/government/news/key-stage-2-test-results-published",
+          "format": "news_article",
+          "public_timestamp": "2012-09-20T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/key-stage-2-test-results-published",
+          "document_type": "edition"
+        },
+        {
+          "title": "Primary test results: standards rising in all subjects",
+          "description": "Eighty thousand more children than 5 years ago will start secondary school secure in reading, writing and arithmetic.",
+          "link": "/government/news/primary-test-results-standards-rising-in-all-subjects",
+          "format": "news_article",
+          "public_timestamp": "2014-08-28T12:20:01.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/primary-test-results-standards-rising-in-all-subjects",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 writing moderation: evaluation of the 2011 to 2012 interim arrangements",
+          "description": "This evaluation explored the impact of the 2012 KS2 writing moderation arrangements on a sample of moderation managers, moderators and schools.",
+          "link": "/government/publications/key-stage-2-writing-moderation-evaluation-of-the-20112012-interim-arrangements",
+          "format": "publication",
+          "public_timestamp": "2012-12-17T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-writing-moderation-evaluation-of-the-20112012-interim-arrangements",
+          "document_type": "edition"
+        },
+        {
+          "title": "Attendance register and test script dispatch",
+          "description": "Instructions for completing attendance registers for the key stage 2 tests, and sending test scripts for marking.",
+          "link": "/government/publications/key-stage-2-attendance-register-and-test-script-dispatch",
+          "format": "publication",
+          "public_timestamp": "2016-03-31T18:52:37.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-attendance-register-and-test-script-dispatch",
+          "document_type": "edition"
+        },
+        {
+          "title": "Register now for primary assessment webinars",
+          "description": "Register to join two interactive webinars about the 2016 national curriculum tests and assessments",
+          "link": "/government/news/register-now-for-primary-assessment-webinars",
+          "format": "news_article",
+          "public_timestamp": "2016-02-18T15:03:08.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/register-now-for-primary-assessment-webinars",
+          "document_type": "edition"
+        },
+        {
+          "title": "Introduction of a new methodology for measuring attainment in key stage 2 science sampling",
+          "description": "Information about how attainment in key stage 2 science sampling is measured",
+          "link": "/government/news/introduction-of-a-new-methodology-for-measuring-attainment-in-key-stage-2-science-sampling",
+          "format": "news_article",
+          "public_timestamp": "2016-01-27T15:11:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/introduction-of-a-new-methodology-for-measuring-attainment-in-key-stage-2-science-sampling",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 pupil achievement figures",
+          "description": "Statistics on 2010 national curriculum assessments at key stage 2 in England, and a statement from Michael Gove.",
+          "link": "/government/news/key-stage-2-pupil-achievement-figures",
+          "format": "news_article",
+          "public_timestamp": "2010-12-17T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/key-stage-2-pupil-achievement-figures",
+          "document_type": "edition"
+        },
+        {
+          "title": "Nicky Morgan and David Walliams launch literacy drive",
+          "description": "The Education Secretary and children’s author issue a call to publishers and schools to make English pupils Europe’s most literate.",
+          "link": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
+          "format": "news_article",
+          "public_timestamp": "2015-09-24T09:59:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/nicky-morgan-and-david-walliams-launch-literacy-drive",
+          "document_type": "edition"
+        },
+        {
+          "title": "Nick Gibb congratulates teachers and pupils on their hard work in key stage 1",
+          "description": "Nick Gibb congratulates thousands of primary school children, teachers and support staff on their hard work at key stage 1. ",
+          "link": "/government/news/nick-gibb-congratulates-teachers-and-pupils-on-their-hard-work-in-key-stage-1",
+          "format": "news_article",
+          "public_timestamp": "2010-08-26T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/nick-gibb-congratulates-teachers-and-pupils-on-their-hard-work-in-key-stage-1",
+          "document_type": "edition"
+        },
+        {
+          "title": "Ofsted updates School Data Dashboard with 2013 results",
+          "description": "Data for key stages 1 and 2 has been updated.",
+          "link": "/government/news/ofsted-updates-school-data-dashboard-with-2013-results",
+          "format": "news_article",
+          "public_timestamp": "2014-03-07T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/ofsted-updates-school-data-dashboard-with-2013-results",
+          "document_type": "edition"
+        },
+        {
+          "title": "NCA tools 'Test orders' section closes this Friday",
+          "description": "Schools can use the NCA tools website to order key stage 1 tasks and test materials and key stage 2 test materials.\r\n\r\n",
+          "link": "/government/news/nca-tools-test-orders-section-closes-this-friday",
+          "format": "news_article",
+          "public_timestamp": "2014-11-25T09:03:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/nca-tools-test-orders-section-closes-this-friday",
+          "document_type": "edition"
+        },
+        {
+          "title": "KS1 assessments data collection 2015: technical specification",
+          "description": "Technical specification defining the scope of the 2015 key stage 1 (KS1) assessments data collection from local authorities.",
+          "link": "/government/publications/ks1-assessments-data-collection-2015-technical-specification",
+          "format": "publication",
+          "public_timestamp": "2015-04-17T16:58:21.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/ks1-assessments-data-collection-2015-technical-specification",
+          "document_type": "edition"
+        },
+        {
+          "title": "Government response to Lord Bew key stage 2 review published",
+          "description": "Government’s response to the review and how the recommendations will be taken forward.",
+          "link": "/government/news/government-response-to-lord-bew-key-stage-2-review-published",
+          "format": "news_article",
+          "public_timestamp": "2011-07-18T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/government-response-to-lord-bew-key-stage-2-review-published",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1 assessments collection 2014: guide",
+          "description": "Guide for local authorities on how to return 2014 key stage 1 assessment results to the Department for Education. ",
+          "link": "/government/publications/key-stage-1-assessments-collection-2014-guide",
+          "format": "publication",
+          "public_timestamp": "2014-06-10T12:24:55.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-assessments-collection-2014-guide",
           "document_type": "edition"
         },
         {
@@ -5261,116 +5338,6 @@
           "document_type": "edition"
         },
         {
-          "title": "NCA tools 'Test orders' section closes this Friday",
-          "description": "Schools can use the NCA tools website to order key stage 1 tasks and test materials and key stage 2 test materials.\r\n\r\n",
-          "link": "/government/news/nca-tools-test-orders-section-closes-this-friday",
-          "format": "news_article",
-          "public_timestamp": "2014-11-25T09:03:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/nca-tools-test-orders-section-closes-this-friday",
-          "document_type": "edition"
-        },
-        {
-          "title": "Nick Gibb congratulates teachers and pupils on their hard work in key stage 1",
-          "description": "Nick Gibb congratulates thousands of primary school children, teachers and support staff on their hard work at key stage 1. ",
-          "link": "/government/news/nick-gibb-congratulates-teachers-and-pupils-on-their-hard-work-in-key-stage-1",
-          "format": "news_article",
-          "public_timestamp": "2010-08-26T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/nick-gibb-congratulates-teachers-and-pupils-on-their-hard-work-in-key-stage-1",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 1 assessments collection 2014: guide",
-          "description": "Guide for local authorities on how to return 2014 key stage 1 assessment results to the Department for Education. ",
-          "link": "/government/publications/key-stage-1-assessments-collection-2014-guide",
-          "format": "publication",
-          "public_timestamp": "2014-06-10T12:24:55.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-1-assessments-collection-2014-guide",
-          "document_type": "edition"
-        },
-        {
-          "title": "English grammar, punctuation and spelling: 2013 technical report",
-          "description": "This report provides an analysis of the key stage 2 English grammar, punctuation and spelling test.",
-          "link": "/government/publications/english-grammar-punctuation-and-spelling-2013-technical-report",
-          "format": "publication",
-          "public_timestamp": "2015-05-29T13:55:58.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/english-grammar-punctuation-and-spelling-2013-technical-report",
-          "document_type": "edition"
-        },
-        {
-          "title": "Government response to Lord Bew key stage 2 review published",
-          "description": "Government’s response to the review and how the recommendations will be taken forward.",
-          "link": "/government/news/government-response-to-lord-bew-key-stage-2-review-published",
-          "format": "news_article",
-          "public_timestamp": "2011-07-18T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/government-response-to-lord-bew-key-stage-2-review-published",
-          "document_type": "edition"
-        },
-        {
-          "title": "NCA tools 'Test orders' section is open",
-          "description": "Schools can use the NCA tools website to order key stage 1 tasks and test materials and key stage 2 test materials.",
-          "link": "/government/news/nca-tools-test-orders-section-is-open",
-          "format": "news_article",
-          "public_timestamp": "2014-09-29T09:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/nca-tools-test-orders-section-is-open",
-          "document_type": "edition"
-        },
-        {
-          "title": "2012 maladministration investigation procedures",
-          "description": "The purpose of this document is to outline procedures followed by STA when investigating allegations of maladministration.",
-          "link": "/government/publications/2012-maladministration-investigation-procedures",
-          "format": "publication",
-          "public_timestamp": "2012-10-01T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2012-maladministration-investigation-procedures",
-          "document_type": "edition"
-        },
-        {
-          "title": "Group performance in the key stage 2 science tests: 2010 and 2011",
-          "description": "A study of how different groups of students performed in the national curriculum science tests in 2010 and 2011.",
-          "link": "/government/publications/group-performance-in-the-key-stage-2-science-tests-2010-and-2011",
-          "format": "publication",
-          "public_timestamp": "2014-02-11T09:30:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/group-performance-in-the-key-stage-2-science-tests-2010-and-2011",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key Stage 2 science sample test results published",
-          "description": "The provisional results of the 2010 Key Stage 2 attainment test in science from sample schools are available.",
-          "link": "/government/news/key-stage-2-science-sample-test-results-published",
-          "format": "news_article",
-          "public_timestamp": "2010-08-10T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/key-stage-2-science-sample-test-results-published",
-          "document_type": "edition"
-        },
-        {
-          "title": "Elizabeth Truss calls for a renaissance in maths",
-          "description": "The Education Minister calls for a renaissance in maths to help meet the demand of UK employers, and announces the removal of calculators from key stage 2 tests.",
-          "link": "/government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths",
-          "format": "speech",
-          "public_timestamp": "2012-11-09T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths",
-          "document_type": "edition"
-        },
-        {
           "title": "Statement from Schools Minister Nick Gibb on Ofqual’s monitoring report of the 2009 key stage 2 tests",
           "description": "Nick Gibb comments on Ofqual’s report on national curriculum tests.",
           "link": "/government/news/statement-from-schools-minister-nick-gibb-on-ofquals-monitoring-report-of-the-2009-key-stage-2-tests",
@@ -5390,6 +5357,39 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/news/key-stage-2-test-results-released",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 access arrangements: an investigation",
+          "description": "This report reviewed a new tool for identifying pupils who are eligible for special access arrangements for KS2 national curriculum tests.",
+          "link": "/government/publications/an-investigation-of-key-stage-2-access-arrangements-procedures",
+          "format": "publication",
+          "public_timestamp": "2013-05-23T04:21:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/an-investigation-of-key-stage-2-access-arrangements-procedures",
+          "document_type": "edition"
+        },
+        {
+          "title": "NCA tools 'Test orders' section is open",
+          "description": "Schools can use the NCA tools website to order key stage 1 tasks and test materials and key stage 2 test materials.",
+          "link": "/government/news/nca-tools-test-orders-section-is-open",
+          "format": "news_article",
+          "public_timestamp": "2014-09-29T09:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/nca-tools-test-orders-section-is-open",
+          "document_type": "edition"
+        },
+        {
+          "title": "Elizabeth Truss calls for a renaissance in maths",
+          "description": "The Education Minister calls for a renaissance in maths to help meet the demand of UK employers, and announces the removal of calculators from key stage 2 tests.",
+          "link": "/government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths",
+          "format": "speech",
+          "public_timestamp": "2012-11-09T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths",
           "document_type": "edition"
         },
         {
@@ -5415,58 +5415,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2 access arrangements: an investigation",
-          "description": "This report reviewed a new tool for identifying pupils who are eligible for special access arrangements for KS2 national curriculum tests.",
-          "link": "/government/publications/an-investigation-of-key-stage-2-access-arrangements-procedures",
+          "title": "Group performance in the key stage 2 science tests: 2010 and 2011",
+          "description": "A study of how different groups of students performed in the national curriculum science tests in 2010 and 2011.",
+          "link": "/government/publications/group-performance-in-the-key-stage-2-science-tests-2010-and-2011",
           "format": "publication",
-          "public_timestamp": "2013-05-23T04:21:00.000+01:00",
+          "public_timestamp": "2014-02-11T09:30:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/an-investigation-of-key-stage-2-access-arrangements-procedures",
+          "_id": "/government/publications/group-performance-in-the-key-stage-2-science-tests-2010-and-2011",
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1 assessments data collection: closed collections",
-          "description": "Documents for software suppliers and anyone else interested in past key stage 1 (KS1) assessments data collections.",
-          "link": "/government/collections/key-stage-1-assessments-data-collection",
-          "format": "document_collection",
-          "public_timestamp": "2016-02-12T17:12:00.000+00:00",
+          "title": "Key Stage 2 science sample test results published",
+          "description": "The provisional results of the 2010 Key Stage 2 attainment test in science from sample schools are available.",
+          "link": "/government/news/key-stage-2-science-sample-test-results-published",
+          "format": "news_article",
+          "public_timestamp": "2010-08-10T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/collections/key-stage-1-assessments-data-collection",
-          "document_type": "edition"
-        },
-        {
-          "title": "Key stage 2 attainment for children recorded as adopted from care",
-          "description": "The key stage 2 attainment of children whose adoptive parents informed their school that they were adopted.",
-          "link": "/government/publications/key-stage-2-attainment-for-children-recorded-as-adopted-from-care",
-          "format": "publication",
-          "public_timestamp": "2014-07-27T10:00:32.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-attainment-for-children-recorded-as-adopted-from-care",
-          "document_type": "edition"
-        },
-        {
-          "title": "Independent review of key stage 2 testing, assessment and accountability: government response",
-          "description": "The government's response to recommendations made in the review into key stage 2 testing, assessment and accountability.",
-          "link": "/government/publications/department-for-education-independent-review-of-key-stage-2-testing-assessment-and-accountability-july-2011",
-          "format": "publication",
-          "public_timestamp": "2011-07-18T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/department-for-education-independent-review-of-key-stage-2-testing-assessment-and-accountability-july-2011",
-          "document_type": "edition"
-        },
-        {
-          "title": "2013 maladministration report",
-          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2013 test cycle.",
-          "link": "/government/publications/2013-maladministration-report",
-          "format": "publication",
-          "public_timestamp": "2014-11-27T14:48:27.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/2013-maladministration-report",
+          "_id": "/government/news/key-stage-2-science-sample-test-results-published",
           "document_type": "edition"
         },
         {
@@ -5481,14 +5448,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Cost of administering SATs in primary school",
-          "description": "Total breakdown of cost of administering standard attainment tests (SATs) for key stages 1 and 2 for the most recent financial year.",
-          "link": "/government/publications/cost-of-administering-sats-in-primary-school",
+          "title": "Investigating reliability in key stage 2 tests",
+          "description": "A study analysing the reliability of key stage 2 science tests. ",
+          "link": "/government/publications/investigating-reliability-in-key-stage-2-tests",
           "format": "publication",
-          "public_timestamp": "2014-08-15T10:34:58.000+01:00",
+          "public_timestamp": "2013-05-16T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/cost-of-administering-sats-in-primary-school",
+          "_id": "/government/publications/investigating-reliability-in-key-stage-2-tests",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 2 attainment for children recorded as adopted from care",
+          "description": "The key stage 2 attainment of children whose adoptive parents informed their school that they were adopted.",
+          "link": "/government/publications/key-stage-2-attainment-for-children-recorded-as-adopted-from-care",
+          "format": "publication",
+          "public_timestamp": "2014-07-27T10:00:32.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-2-attainment-for-children-recorded-as-adopted-from-care",
           "document_type": "edition"
         },
         {
@@ -5511,6 +5489,28 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/key-stage-1-assessments-specification-for-the-2014-data-return",
+          "document_type": "edition"
+        },
+        {
+          "title": "Independent review of key stage 2 testing, assessment and accountability: government response",
+          "description": "The government's response to recommendations made in the review into key stage 2 testing, assessment and accountability.",
+          "link": "/government/publications/department-for-education-independent-review-of-key-stage-2-testing-assessment-and-accountability-july-2011",
+          "format": "publication",
+          "public_timestamp": "2011-07-18T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/department-for-education-independent-review-of-key-stage-2-testing-assessment-and-accountability-july-2011",
+          "document_type": "edition"
+        },
+        {
+          "title": "2013 maladministration report",
+          "description": "This report details the range of allegations of maladministration reported to the STA maladministration team throughout the 2013 test cycle.",
+          "link": "/government/publications/2013-maladministration-report",
+          "format": "publication",
+          "public_timestamp": "2014-11-27T14:48:27.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/2013-maladministration-report",
           "document_type": "edition"
         }
       ],
@@ -5569,17 +5569,6 @@
           "document_type": "edition"
         },
         {
-          "title": "New curriculum will make education system 'envy of the world'",
-          "description": "As a new school term begins, millions of children will be taught a new ‘world-class’ curriculum to prepare them for life in modern Britain.",
-          "link": "/government/news/new-curriculum-will-make-education-system-envy-of-the-world",
-          "format": "news_article",
-          "public_timestamp": "2014-09-04T15:48:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/new-curriculum-will-make-education-system-envy-of-the-world",
-          "document_type": "edition"
-        },
-        {
           "title": "Art, craft and design education: making a mark",
           "description": "Ofsted survey report evaluating the strengths and weaknesses of art, craft and design education in schools and colleges in England.",
           "link": "/government/publications/art-craft-and-design-education-making-a-mark",
@@ -5588,6 +5577,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/art-craft-and-design-education-making-a-mark",
+          "document_type": "edition"
+        },
+        {
+          "title": "New curriculum will make education system 'envy of the world'",
+          "description": "As a new school term begins, millions of children will be taught a new ‘world-class’ curriculum to prepare them for life in modern Britain.",
+          "link": "/government/news/new-curriculum-will-make-education-system-envy-of-the-world",
+          "format": "news_article",
+          "public_timestamp": "2014-09-04T15:48:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/new-curriculum-will-make-education-system-envy-of-the-world",
           "document_type": "edition"
         },
         {
@@ -5623,17 +5623,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Disapplying aspects of the national curriculum",
-          "description": "Guidance explaining when and how to disapply aspects of the national curriculum to meet pupils' particular needs.",
-          "link": "/government/publications/disapplying-aspects-of-the-national-curriculum",
-          "format": "publication",
-          "public_timestamp": "2006-07-01T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/disapplying-aspects-of-the-national-curriculum",
-          "document_type": "edition"
-        },
-        {
           "title": "Commission on Assessment Without Levels: government response",
           "description": "The government's response to recommendations in the Commission on Assessment Without Levels' final report.",
           "link": "/government/publications/commission-on-assessment-without-levels-government-response",
@@ -5642,6 +5631,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/commission-on-assessment-without-levels-government-response",
+          "document_type": "edition"
+        },
+        {
+          "title": "Disapplying aspects of the national curriculum",
+          "description": "Guidance explaining when and how to disapply aspects of the national curriculum to meet pupils' particular needs.",
+          "link": "/government/publications/disapplying-aspects-of-the-national-curriculum",
+          "format": "publication",
+          "public_timestamp": "2006-07-01T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/disapplying-aspects-of-the-national-curriculum",
           "document_type": "edition"
         },
         {
@@ -5667,17 +5667,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Education reform: a world-class curriculum to drive up standards and fuel aspiration",
-          "description": "Michael Gove announced today the final programmes of study for the national curriculum for 5 to 16-year-olds.",
-          "link": "/government/news/education-reform-a-world-class-curriculum-to-drive-up-standards-and-fuel-aspiration",
-          "format": "news_article",
-          "public_timestamp": "2013-07-08T10:59:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/education-reform-a-world-class-curriculum-to-drive-up-standards-and-fuel-aspiration",
-          "document_type": "edition"
-        },
-        {
           "title": "Request about the National Curriculum Review",
           "description": "Information about stakeholders who have been involved in the consultation on the review of the National Curriculum.",
           "link": "/government/publications/request-about-the-national-curriculum-review",
@@ -5700,25 +5689,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Elizabeth Truss speaks about curriculum reform",
-          "description": "Elizabeth Truss, Parliamentary Under Secretary of State for Education and Childcare, speaks to the CBI about improving education and the importance of curriculum reform. ",
-          "link": "/government/speeches/elizabeth-truss-speaks-about-curriculum-reform",
-          "format": "speech",
-          "public_timestamp": "2013-09-18T15:24:39.000+01:00",
+          "title": "Education reform: a world-class curriculum to drive up standards and fuel aspiration",
+          "description": "Michael Gove announced today the final programmes of study for the national curriculum for 5 to 16-year-olds.",
+          "link": "/government/news/education-reform-a-world-class-curriculum-to-drive-up-standards-and-fuel-aspiration",
+          "format": "news_article",
+          "public_timestamp": "2013-07-08T10:59:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/elizabeth-truss-speaks-about-curriculum-reform",
-          "document_type": "edition"
-        },
-        {
-          "title": "Nick Gibb speaks at the Music Education Expo",
-          "description": "Minister of State for School Reform Nick Gibb outlines the government’s support for music education in schools.",
-          "link": "/government/speeches/nick-gibb-speaks-at-the-music-education-expo",
-          "format": "speech",
-          "public_timestamp": "2015-03-12T14:53:41.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/nick-gibb-speaks-at-the-music-education-expo",
+          "_id": "/government/news/education-reform-a-world-class-curriculum-to-drive-up-standards-and-fuel-aspiration",
           "document_type": "edition"
         },
         {
@@ -5730,6 +5708,39 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/what-is-the-research-evidence-on-writing",
+          "document_type": "edition"
+        },
+        {
+          "title": "Elizabeth Truss speaks about curriculum reform",
+          "description": "Elizabeth Truss, Parliamentary Under Secretary of State for Education and Childcare, speaks to the CBI about improving education and the importance of curriculum reform. ",
+          "link": "/government/speeches/elizabeth-truss-speaks-about-curriculum-reform",
+          "format": "speech",
+          "public_timestamp": "2013-09-18T15:24:39.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/elizabeth-truss-speaks-about-curriculum-reform",
+          "document_type": "edition"
+        },
+        {
+          "title": "Michael Gove speaks to the Royal Society on maths and science",
+          "description": "Education Secretary Michael Gove speaks to the Royal Society.",
+          "link": "/government/speeches/michael-gove-speaks-to-the-royal-society-on-maths-and-science",
+          "format": "speech",
+          "public_timestamp": "2013-11-20T11:35:17.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/michael-gove-speaks-to-the-royal-society-on-maths-and-science",
+          "document_type": "edition"
+        },
+        {
+          "title": "Nick Gibb speaks at the Music Education Expo",
+          "description": "Minister of State for School Reform Nick Gibb outlines the government’s support for music education in schools.",
+          "link": "/government/speeches/nick-gibb-speaks-at-the-music-education-expo",
+          "format": "speech",
+          "public_timestamp": "2015-03-12T14:53:41.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/speeches/nick-gibb-speaks-at-the-music-education-expo",
           "document_type": "edition"
         },
         {
@@ -5755,17 +5766,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove speaks to the Royal Society on maths and science",
-          "description": "Education Secretary Michael Gove speaks to the Royal Society.",
-          "link": "/government/speeches/michael-gove-speaks-to-the-royal-society-on-maths-and-science",
-          "format": "speech",
-          "public_timestamp": "2013-11-20T11:35:17.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/michael-gove-speaks-to-the-royal-society-on-maths-and-science",
-          "document_type": "edition"
-        },
-        {
           "title": "The Sutherland Inquiry: an independent inquiry into the delivery of National Curriculum tests in 2008",
           "description": "This document contains the following information: The Sutherland Inquiry: an independent inquiry into the delivery of National Curriculum tests in 2008",
           "link": "/government/publications/the-sutherland-inquiry-an-independent-inquiry-into-the-delivery-of-national-curriculum-tests-in-2008",
@@ -5788,16 +5788,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Closed organisation: Sutherland Inquiry",
-          "description": "The inquiry was setup to review the circumstances surrounding the delay to the marking of National Curriculum tests in 2008.",
-          "link": "/government/organisations/sutherland-inquiry",
-          "format": "organisation",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/organisations/sutherland-inquiry",
-          "document_type": "edition"
-        },
-        {
           "title": "Elizabeth Truss on increasing the number of pupils studying Mandarin",
           "description": "Education Minister Elizabeth Truss speaks about increasing the number of children studying Mandarin.",
           "link": "/government/speeches/elizabeth-truss-on-increasing-the-number-of-pupils-studying-mandarin",
@@ -5806,6 +5796,16 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/speeches/elizabeth-truss-on-increasing-the-number-of-pupils-studying-mandarin",
+          "document_type": "edition"
+        },
+        {
+          "title": "Closed organisation: Sutherland Inquiry",
+          "description": "The inquiry was setup to review the circumstances surrounding the delay to the marking of National Curriculum tests in 2008.",
+          "link": "/government/organisations/sutherland-inquiry",
+          "format": "organisation",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/organisations/sutherland-inquiry",
           "document_type": "edition"
         },
         {
@@ -5897,25 +5897,25 @@
           "document_type": "edition"
         },
         {
-          "title": "‘The school revolution’: how reforms are transforming schools",
-          "description": "The Department for Education has published a film detailing the education reforms that are transforming schools in England.",
-          "link": "/government/news/the-school-revolution-how-reforms-are-transforming-schools",
-          "format": "news_article",
-          "public_timestamp": "2014-07-10T18:24:00.000+01:00",
+          "title": "Michael Gove to Westminster Academy",
+          "description": "The Secretary of State sets out his vision for future education policy at a Teach First event at Westminster Academy.",
+          "link": "/government/speeches/michael-gove-to-westminster-academy",
+          "format": "speech",
+          "public_timestamp": "2010-11-25T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/the-school-revolution-how-reforms-are-transforming-schools",
+          "_id": "/government/speeches/michael-gove-to-westminster-academy",
           "document_type": "edition"
         },
         {
-          "title": "Education Secretary Michael Gove's speech to ASCL",
-          "description": "Michael Gove's speech on the future of education to the Association of School and College Leaders.",
-          "link": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "title": "Michael Gove to the Durand Academy",
+          "description": "The Secretary of State talks about the making of an 'educational underclass'.",
+          "link": "/government/speeches/michael-gove-to-the-durand-academy",
           "format": "speech",
-          "public_timestamp": "2012-03-26T01:00:00.000+01:00",
+          "public_timestamp": "2011-09-01T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "_id": "/government/speeches/michael-gove-to-the-durand-academy",
           "document_type": "edition"
         },
         {
@@ -5930,14 +5930,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Michael Gove to Westminster Academy",
-          "description": "The Secretary of State sets out his vision for future education policy at a Teach First event at Westminster Academy.",
-          "link": "/government/speeches/michael-gove-to-westminster-academy",
+          "title": "Education Secretary Michael Gove's speech to ASCL",
+          "description": "Michael Gove's speech on the future of education to the Association of School and College Leaders.",
+          "link": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
           "format": "speech",
-          "public_timestamp": "2010-11-25T00:00:00.000+00:00",
+          "public_timestamp": "2012-03-26T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/speeches/michael-gove-to-westminster-academy",
+          "_id": "/government/speeches/education-secretary-michael-goves-speech-to-ascl",
+          "document_type": "edition"
+        },
+        {
+          "title": "‘The school revolution’: how reforms are transforming schools",
+          "description": "The Department for Education has published a film detailing the education reforms that are transforming schools in England.",
+          "link": "/government/news/the-school-revolution-how-reforms-are-transforming-schools",
+          "format": "news_article",
+          "public_timestamp": "2014-07-10T18:24:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/the-school-revolution-how-reforms-are-transforming-schools",
           "document_type": "edition"
         },
         {
@@ -5960,17 +5971,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/news/the-department-for-educations-response-to-public-comments-on-the-coalition-agreement-on-schools",
-          "document_type": "edition"
-        },
-        {
-          "title": "Michael Gove to the Durand Academy",
-          "description": "The Secretary of State talks about the making of an 'educational underclass'.",
-          "link": "/government/speeches/michael-gove-to-the-durand-academy",
-          "format": "speech",
-          "public_timestamp": "2011-09-01T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/speeches/michael-gove-to-the-durand-academy",
           "document_type": "edition"
         },
         {
@@ -6029,17 +6029,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening check: administration",
-          "description": "Check administration guidance (CAG) for headteachers and teachers administering and scoring the phonics screening check.",
-          "link": "/government/collections/phonics-screening-check-administration",
-          "format": "document_collection",
-          "public_timestamp": "2016-06-27T13:18:25.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/collections/phonics-screening-check-administration",
-          "document_type": "edition"
-        },
-        {
           "title": "Teaching phonics: information for schools",
           "description": "Documents on effective phonics teaching strategies.",
           "link": "/government/collections/phonics",
@@ -6048,6 +6037,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/collections/phonics",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check: administration",
+          "description": "Check administration guidance (CAG) for headteachers and teachers administering and scoring the phonics screening check.",
+          "link": "/government/collections/phonics-screening-check-administration",
+          "format": "document_collection",
+          "public_timestamp": "2016-06-27T13:18:25.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/collections/phonics-screening-check-administration",
           "document_type": "edition"
         },
         {
@@ -6062,17 +6062,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 1: phonics screening check administration guidance",
-          "description": "Check administration guidance (CAG) for headteachers and teachers administering and scoring the 2016 phonics screening check.",
-          "link": "/government/publications/key-stage-1-phonics-screening-check-administration-guidance",
-          "format": "publication",
-          "public_timestamp": "2016-06-27T13:17:38.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-1-phonics-screening-check-administration-guidance",
-          "document_type": "edition"
-        },
-        {
           "title": "Phonics screening check: 2015 materials",
           "description": "Scoring guidance, pupils' materials and answer sheet for the 2015 phonics screening check.",
           "link": "/government/publications/phonics-screening-check-2015-materials",
@@ -6081,6 +6070,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-screening-check-2015-materials",
+          "document_type": "edition"
+        },
+        {
+          "title": "Key stage 1: phonics screening check administration guidance",
+          "description": "Check administration guidance (CAG) for headteachers and teachers administering and scoring the 2016 phonics screening check.",
+          "link": "/government/publications/key-stage-1-phonics-screening-check-administration-guidance",
+          "format": "publication",
+          "public_timestamp": "2016-06-27T13:17:38.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/key-stage-1-phonics-screening-check-administration-guidance",
           "document_type": "edition"
         },
         {
@@ -6128,17 +6128,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Key stage 2 tests and phonics screening check: security advice",
-          "description": "Information for headteachers and teachers on how to keep key stage 2 tests and phonics screening check materials secure.",
-          "link": "/government/publications/key-stage-2-tests-and-phonics-screening-check-keep-materials-secure",
-          "format": "publication",
-          "public_timestamp": "2015-03-19T16:55:44.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/key-stage-2-tests-and-phonics-screening-check-keep-materials-secure",
-          "document_type": "edition"
-        },
-        {
           "title": "Letters and sounds: principles and practice of high quality phonics",
           "description": "Phase 1 of a 6-phase teaching programme to help practitioners and teachers teach children how the alphabet works for reading and spelling.",
           "link": "/government/publications/letters-and-sounds-principles-and-practice-of-high-quality-phonics-phase-one-teaching-programme",
@@ -6150,25 +6139,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening check: 2013 materials",
-          "description": "Scoring guidance, children's materials and answer sheet for the 2013 phonics screening check.",
-          "link": "/government/publications/phonics-screening-check-2013-materials",
+          "title": "Key stage 2 tests and phonics screening check: security advice",
+          "description": "Information for headteachers and teachers on how to keep key stage 2 tests and phonics screening check materials secure.",
+          "link": "/government/publications/key-stage-2-tests-and-phonics-screening-check-keep-materials-secure",
           "format": "publication",
-          "public_timestamp": "2013-06-28T00:00:00.000+01:00",
+          "public_timestamp": "2015-03-19T16:55:44.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-2013-materials",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics self-assessment form: Letters and Sounds",
-          "description": "Information about the Letters and Sounds programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-letters-and-sounds",
-          "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-letters-and-sounds",
+          "_id": "/government/publications/key-stage-2-tests-and-phonics-screening-check-keep-materials-secure",
           "document_type": "edition"
         },
         {
@@ -6194,14 +6172,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Jolly Phonics",
-          "description": "Information about the Jolly Phonics programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-jolly-phonics",
+          "title": "Phonics self-assessment form: Letters and Sounds",
+          "description": "Information about the Letters and Sounds programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-letters-and-sounds",
           "format": "publication",
           "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-jolly-phonics",
+          "_id": "/government/publications/phonics-self-assessment-form-letters-and-sounds",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check: 2013 materials",
+          "description": "Scoring guidance, children's materials and answer sheet for the 2013 phonics screening check.",
+          "link": "/government/publications/phonics-screening-check-2013-materials",
+          "format": "publication",
+          "public_timestamp": "2013-06-28T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-check-2013-materials",
           "document_type": "edition"
         },
         {
@@ -6213,6 +6202,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/news/reading-at-an-early-age-the-key-to-success",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Jolly Phonics",
+          "description": "Information about the Jolly Phonics programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-jolly-phonics",
+          "format": "publication",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-self-assessment-form-jolly-phonics",
           "document_type": "edition"
         },
         {
@@ -6238,17 +6238,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Letterland Phonics (revised edition)",
-          "description": "Information about the revised Letterland Phonics (revised edition) programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-letterland-phonics-revised-edition",
-          "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-letterland-phonics-revised-edition",
-          "document_type": "edition"
-        },
-        {
           "title": "Phonics screening check data collection: guide to submitting data",
           "description": "How local authorities should collect phonics screening check data from all local-authority-maintained schools, academies and free schools.",
           "link": "/guidance/phonics-screening-check-data-collection",
@@ -6257,6 +6246,17 @@
           "index": "detailed",
           "es_score": null,
           "_id": "/guidance/phonics-screening-check-data-collection",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check evaluation: final report",
+          "description": "Research into the effectiveness of schools’ phonics teaching practices.",
+          "link": "/government/publications/phonics-screening-check-evaluation-final-report",
+          "format": "publication",
+          "public_timestamp": "2015-06-25T10:01:11.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-check-evaluation-final-report",
           "document_type": "edition"
         },
         {
@@ -6282,14 +6282,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening check evaluation: final report",
-          "description": "Research into the effectiveness of schools’ phonics teaching practices.",
-          "link": "/government/publications/phonics-screening-check-evaluation-final-report",
+          "title": "Phonics self-assessment form: Letterland Phonics (revised edition)",
+          "description": "Information about the revised Letterland Phonics (revised edition) programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-letterland-phonics-revised-edition",
           "format": "publication",
-          "public_timestamp": "2015-06-25T10:01:11.000+01:00",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-evaluation-final-report",
+          "_id": "/government/publications/phonics-self-assessment-form-letterland-phonics-revised-edition",
           "document_type": "edition"
         },
         {
@@ -6301,17 +6301,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-screening-check-responding-to-the-results",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check evaluation",
-          "description": "Research into the effectiveness of schools’ phonics teaching practices.",
-          "link": "/government/publications/phonics-screening-check-evaluation",
-          "format": "publication",
-          "public_timestamp": "2014-05-01T09:31:01.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-evaluation",
           "document_type": "edition"
         },
         {
@@ -6337,6 +6326,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Phonics screening check evaluation",
+          "description": "Research into the effectiveness of schools’ phonics teaching practices.",
+          "link": "/government/publications/phonics-screening-check-evaluation",
+          "format": "publication",
+          "public_timestamp": "2014-05-01T09:31:01.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-check-evaluation",
+          "document_type": "edition"
+        },
+        {
           "title": "Phonics reading check and key stage 1 results published",
           "description": "National, regional and local authority results for the year 1 phonics reading check and key stage 1 results are published today.",
           "link": "/government/news/phonics-reading-check-and-key-stage-1-results-published",
@@ -6356,72 +6356,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-self-assessment-form-tap-tap-bat-system",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check threshold published",
-          "description": "Information about the 2014 phonics threshold mark. ",
-          "link": "/government/news/phonics-screening-check-threshold-published-today",
-          "format": "news_article",
-          "public_timestamp": "2014-06-30T10:13:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/phonics-screening-check-threshold-published-today",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check: how to carry out a monitoring visit",
-          "description": "Instructions for local authority monitoring visitors, including the monitoring visits form.",
-          "link": "/guidance/phonics-screening-check-how-to-carry-out-a-monitoring-visit",
-          "format": "detailed_guidance",
-          "public_timestamp": "2016-04-11T16:24:17.000+01:00",
-          "index": "detailed",
-          "es_score": null,
-          "_id": "/guidance/phonics-screening-check-how-to-carry-out-a-monitoring-visit",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check: technical reports",
-          "description": "Reports providing analysis of the phonics screening check following administration in 2011, 2012 and 2013.",
-          "link": "/government/collections/phonics-screening-check-technical-reports",
-          "format": "document_collection",
-          "public_timestamp": "2016-05-09T16:13:07.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/collections/phonics-screening-check-technical-reports",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check data collection 2014: technical specification",
-          "description": "Technical specification for software suppliers defining the scope of the phonics screening check data collection 2014.",
-          "link": "/government/publications/phonics-screening-check-data-collection-2014-technical-specification",
-          "format": "publication",
-          "public_timestamp": "2014-04-08T15:10:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-data-collection-2014-technical-specification",
-          "document_type": "edition"
-        },
-        {
-          "title": "Evaluation of the phonics screening check: first interim report",
-          "description": "This first interim report sets out the findings from an evaluation of the phonics check.",
-          "link": "/government/publications/evaluation-of-the-phonics-screening-check-first-interim-report",
-          "format": "publication",
-          "public_timestamp": "2013-05-20T13:45:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/evaluation-of-the-phonics-screening-check-first-interim-report",
-          "document_type": "edition"
-        },
-        {
-          "title": "Funding for phonics teaching to improve children’s reading",
-          "description": "Schools Minister announces matched funding scheme for phonics resources to drive up reading standards.",
-          "link": "/government/news/funding-for-phonics-teaching-to-improve-childrens-reading",
-          "format": "news_article",
-          "public_timestamp": "2011-04-06T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/funding-for-phonics-teaching-to-improve-childrens-reading",
           "document_type": "edition"
         },
         {
@@ -6447,25 +6381,91 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Letterland 'My Alphabet' storybooks",
-          "description": "Information about the Letterland 'My Alphabet' storybooks programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-letterland-my-alphabet-storybooks",
-          "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
-          "index": "government",
+          "title": "Phonics screening check: how to carry out a monitoring visit",
+          "description": "Instructions for local authority monitoring visitors, including the monitoring visits form.",
+          "link": "/guidance/phonics-screening-check-how-to-carry-out-a-monitoring-visit",
+          "format": "detailed_guidance",
+          "public_timestamp": "2016-04-11T16:24:17.000+01:00",
+          "index": "detailed",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-letterland-my-alphabet-storybooks",
+          "_id": "/guidance/phonics-screening-check-how-to-carry-out-a-monitoring-visit",
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Sound Phonics",
-          "description": "Information about the Sound Phonics programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-sound-phonics",
+          "title": "Phonics screening check data collection 2014: technical specification",
+          "description": "Technical specification for software suppliers defining the scope of the phonics screening check data collection 2014.",
+          "link": "/government/publications/phonics-screening-check-data-collection-2014-technical-specification",
+          "format": "publication",
+          "public_timestamp": "2014-04-08T15:10:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-check-data-collection-2014-technical-specification",
+          "document_type": "edition"
+        },
+        {
+          "title": "Evaluation of the phonics screening check: first interim report",
+          "description": "This first interim report sets out the findings from an evaluation of the phonics check.",
+          "link": "/government/publications/evaluation-of-the-phonics-screening-check-first-interim-report",
+          "format": "publication",
+          "public_timestamp": "2013-05-20T13:45:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/evaluation-of-the-phonics-screening-check-first-interim-report",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check threshold published",
+          "description": "Information about the 2014 phonics threshold mark. ",
+          "link": "/government/news/phonics-screening-check-threshold-published-today",
+          "format": "news_article",
+          "public_timestamp": "2014-06-30T10:13:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/phonics-screening-check-threshold-published-today",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check: technical reports",
+          "description": "Reports providing analysis of the phonics screening check following administration in 2011, 2012 and 2013.",
+          "link": "/government/collections/phonics-screening-check-technical-reports",
+          "format": "document_collection",
+          "public_timestamp": "2016-05-09T16:13:07.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/collections/phonics-screening-check-technical-reports",
+          "document_type": "edition"
+        },
+        {
+          "title": "Funding for phonics teaching to improve children’s reading",
+          "description": "Schools Minister announces matched funding scheme for phonics resources to drive up reading standards.",
+          "link": "/government/news/funding-for-phonics-teaching-to-improve-childrens-reading",
+          "format": "news_article",
+          "public_timestamp": "2011-04-06T01:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/funding-for-phonics-teaching-to-improve-childrens-reading",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening data collection 2016: technical specification",
+          "description": "This document defines the scope of the 2016 phonics screening check data collection from local authorities.",
+          "link": "/government/publications/phonics-screening-data-collection-2016-technical-specification",
+          "format": "publication",
+          "public_timestamp": "2016-02-01T13:14:19.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-data-collection-2016-technical-specification",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Project X Phonics",
+          "description": "Information about the Project X Phonics programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-project-x-phonics",
           "format": "publication",
           "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-sound-phonics",
+          "_id": "/government/publications/phonics-self-assessment-form-project-x-phonics",
           "document_type": "edition"
         },
         {
@@ -6491,14 +6491,36 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics check and key stage 1 results",
-          "description": "National, regional and local authority results for the phonics reading check and key stage 1 results have been published.",
-          "link": "/government/news/phonics-check-and-key-stage-1-results",
-          "format": "news_article",
-          "public_timestamp": "2013-10-03T11:12:02.000+01:00",
+          "title": "Phonics self-assessment form: Dandelion Books",
+          "description": "Information about the Dandelion Books programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-dandelion-books",
+          "format": "publication",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/news/phonics-check-and-key-stage-1-results",
+          "_id": "/government/publications/phonics-self-assessment-form-dandelion-books",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Letterland 'My Alphabet' storybooks",
+          "description": "Information about the Letterland 'My Alphabet' storybooks programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-letterland-my-alphabet-storybooks",
+          "format": "publication",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-self-assessment-form-letterland-my-alphabet-storybooks",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics funding: thousands of schools sign up",
+          "description": "Thousands of primary schools have already signed up to spend more than £7.7 million on new phonics products and training to drive up their pupils’ standards of reading, new Department for Education figures show today.",
+          "link": "/government/news/phonics-funding-thousands-of-schools-sign-up",
+          "format": "news_article",
+          "public_timestamp": "2012-01-19T00:00:00.000+00:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/phonics-funding-thousands-of-schools-sign-up",
           "document_type": "edition"
         },
         {
@@ -6513,14 +6535,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Jolly Readers",
-          "description": "Information about the Jolly Readers programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-jolly-readers",
+          "title": "Phonics screening check data collection 2015: guide",
+          "description": "How local authorities should complete and return the 2015 phonics screening check data collection.",
+          "link": "/government/publications/phonics-screening-check-data-collection-2015-guide",
           "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
+          "public_timestamp": "2015-06-08T11:51:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-jolly-readers",
+          "_id": "/government/publications/phonics-screening-check-data-collection-2015-guide",
           "document_type": "edition"
         },
         {
@@ -6535,14 +6557,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening data collection 2016: technical specification",
-          "description": "This document defines the scope of the 2016 phonics screening check data collection from local authorities.",
-          "link": "/government/publications/phonics-screening-data-collection-2016-technical-specification",
+          "title": "Phonics self-assessment form: Reading Corner Phonics",
+          "description": "Information about the Reading Corner Phonics programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-reading-corner-phonics",
           "format": "publication",
-          "public_timestamp": "2016-02-01T13:14:19.000+00:00",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-screening-data-collection-2016-technical-specification",
+          "_id": "/government/publications/phonics-self-assessment-form-reading-corner-phonics",
           "document_type": "edition"
         },
         {
@@ -6557,14 +6579,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening data collection 2015: technical specification",
-          "description": "This document defines the scope of the 2015 phonics screening check data collection from local authorities.",
-          "link": "/government/publications/phonics-screening-data-collection-2015-technical-specification",
+          "title": "Phonics screening check: pilot 2011 technical report",
+          "description": "This report provides an analysis of the phonics screening check following a pilot in 2011.",
+          "link": "/government/publications/phonics-screening-check-pilot-2011-technical-report",
           "format": "publication",
-          "public_timestamp": "2015-04-17T16:58:20.000+01:00",
+          "public_timestamp": "2012-02-16T00:00:00.000+00:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-screening-data-collection-2015-technical-specification",
+          "_id": "/government/publications/phonics-screening-check-pilot-2011-technical-report",
           "document_type": "edition"
         },
         {
@@ -6576,6 +6598,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/news/100000-more-pupils-on-track-to-succeed-in-reading-via-phonics",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics check and key stage 1 results",
+          "description": "National, regional and local authority results for the phonics reading check and key stage 1 results have been published.",
+          "link": "/government/news/phonics-check-and-key-stage-1-results",
+          "format": "news_article",
+          "public_timestamp": "2013-10-03T11:12:02.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/news/phonics-check-and-key-stage-1-results",
           "document_type": "edition"
         },
         {
@@ -6601,36 +6634,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Project X Phonics",
-          "description": "Information about the Project X Phonics programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-project-x-phonics",
+          "title": "Phonics self-assessment form: Sound Phonics",
+          "description": "Information about the Sound Phonics programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-sound-phonics",
           "format": "publication",
           "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-project-x-phonics",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check: pilot 2011 technical report",
-          "description": "This report provides an analysis of the phonics screening check following a pilot in 2011.",
-          "link": "/government/publications/phonics-screening-check-pilot-2011-technical-report",
-          "format": "publication",
-          "public_timestamp": "2012-02-16T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-pilot-2011-technical-report",
-          "document_type": "edition"
-        },
-        {
-          "title": "New phonics check will identify thousands of children needing extra reading help",
-          "description": "Thousands of children will receive the extra support they need to become confident, fluent readers thanks to the DfE's new phonics check, an independent study reveals.",
-          "link": "/government/news/new-phonics-check-will-identify-thousands-of-children-needing-extra-reading-help",
-          "format": "news_article",
-          "public_timestamp": "2011-09-16T01:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/new-phonics-check-will-identify-thousands-of-children-needing-extra-reading-help",
+          "_id": "/government/publications/phonics-self-assessment-form-sound-phonics",
           "document_type": "edition"
         },
         {
@@ -6645,17 +6656,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics: year 1 screening check statistics",
-          "description": "Number of schools in which 95% or more of eligible pupils reached the required phonics standard.",
-          "link": "/government/publications/phonics-year-1-screening-check-statistics",
-          "format": "publication",
-          "public_timestamp": "2014-09-25T16:41:21.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-year-1-screening-check-statistics",
-          "document_type": "edition"
-        },
-        {
           "title": "Phonics self-assessment form: Autopress Education",
           "description": "Information about the Autopress Education programme and how it fulfils the department’s core criteria.",
           "link": "/government/publications/phonics-self-assessment-form-autopress-education",
@@ -6667,14 +6667,25 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Songbirds Phonics",
-          "description": "Information about the Songbirds Phonics programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-songbirds-phonics",
+          "title": "Phonics: year 1 screening check statistics",
+          "description": "Number of schools in which 95% or more of eligible pupils reached the required phonics standard.",
+          "link": "/government/publications/phonics-year-1-screening-check-statistics",
+          "format": "publication",
+          "public_timestamp": "2014-09-25T16:41:21.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-year-1-screening-check-statistics",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Jolly Readers",
+          "description": "Information about the Jolly Readers programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-jolly-readers",
           "format": "publication",
           "public_timestamp": "2013-05-13T00:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-songbirds-phonics",
+          "_id": "/government/publications/phonics-self-assessment-form-jolly-readers",
           "document_type": "edition"
         },
         {
@@ -6686,28 +6697,6 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-self-assessment-form-monster-phonics",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics self-assessment form: Adaptaboard Advanced",
-          "description": "Information about the Adaptaboard Advanced programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-adaptaboard-advanced",
-          "format": "publication",
-          "public_timestamp": "2013-05-17T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-adaptaboard-advanced",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics funding: thousands of schools sign up",
-          "description": "Thousands of primary schools have already signed up to spend more than £7.7 million on new phonics products and training to drive up their pupils’ standards of reading, new Department for Education figures show today.",
-          "link": "/government/news/phonics-funding-thousands-of-schools-sign-up",
-          "format": "news_article",
-          "public_timestamp": "2012-01-19T00:00:00.000+00:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/news/phonics-funding-thousands-of-schools-sign-up",
           "document_type": "edition"
         },
         {
@@ -6733,17 +6722,6 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics screening check data collection 2015: guide",
-          "description": "How local authorities should complete and return the 2015 phonics screening check data collection.",
-          "link": "/government/publications/phonics-screening-check-data-collection-2015-guide",
-          "format": "publication",
-          "public_timestamp": "2015-06-08T11:51:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-data-collection-2015-guide",
-          "document_type": "edition"
-        },
-        {
           "title": "Phonics self-assessment form: Teach Your Monster to Read",
           "description": "Information about the Teach Your Monster to Read programme and how it fulfils the department’s core criteria.",
           "link": "/government/publications/phonics-self-assessment-form-teach-your-monster-to-read",
@@ -6752,6 +6730,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-self-assessment-form-teach-your-monster-to-read",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Adaptaboard Advanced",
+          "description": "Information about the Adaptaboard Advanced programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-adaptaboard-advanced",
+          "format": "publication",
+          "public_timestamp": "2013-05-17T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-self-assessment-form-adaptaboard-advanced",
           "document_type": "edition"
         },
         {
@@ -6766,6 +6755,17 @@
           "document_type": "edition"
         },
         {
+          "title": "Phonics screening data collection 2015: technical specification",
+          "description": "This document defines the scope of the 2015 phonics screening check data collection from local authorities.",
+          "link": "/government/publications/phonics-screening-data-collection-2015-technical-specification",
+          "format": "publication",
+          "public_timestamp": "2015-04-17T16:58:20.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-data-collection-2015-technical-specification",
+          "document_type": "edition"
+        },
+        {
           "title": "Phonics screening check data collection 2012: technical specification",
           "description": "Technical specification for software suppliers defining the scope of the year 1 phonics screening check data collection 2012.",
           "link": "/government/publications/phonics-screening-check-data-collection-2012-technical-specification",
@@ -6777,36 +6777,14 @@
           "document_type": "edition"
         },
         {
-          "title": "Phonics self-assessment form: Dandelion Books",
-          "description": "Information about the Dandelion Books programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-dandelion-books",
-          "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
+          "title": "New phonics check will identify thousands of children needing extra reading help",
+          "description": "Thousands of children will receive the extra support they need to become confident, fluent readers thanks to the DfE's new phonics check, an independent study reveals.",
+          "link": "/government/news/new-phonics-check-will-identify-thousands-of-children-needing-extra-reading-help",
+          "format": "news_article",
+          "public_timestamp": "2011-09-16T01:00:00.000+01:00",
           "index": "government",
           "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-dandelion-books",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics screening check data collection 2013: technical specification",
-          "description": "Technical specification for software suppliers defining the scope of the phonics screening check data collection 2013.",
-          "link": "/government/publications/phonics-screening-check-data-collection-2013-technical-specification",
-          "format": "publication",
-          "public_timestamp": "2013-04-13T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-screening-check-data-collection-2013-technical-specification",
-          "document_type": "edition"
-        },
-        {
-          "title": "Phonics self-assessment form: Reading Corner Phonics",
-          "description": "Information about the Reading Corner Phonics programme and how it fulfils the department’s core criteria.",
-          "link": "/government/publications/phonics-self-assessment-form-reading-corner-phonics",
-          "format": "publication",
-          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
-          "index": "government",
-          "es_score": null,
-          "_id": "/government/publications/phonics-self-assessment-form-reading-corner-phonics",
+          "_id": "/government/news/new-phonics-check-will-identify-thousands-of-children-needing-extra-reading-help",
           "document_type": "edition"
         },
         {
@@ -6818,6 +6796,17 @@
           "index": "government",
           "es_score": null,
           "_id": "/government/publications/phonics-self-assessment-form-tts-group",
+          "document_type": "edition"
+        },
+        {
+          "title": "Phonics self-assessment form: Songbirds Phonics",
+          "description": "Information about the Songbirds Phonics programme and how it fulfils the department’s core criteria.",
+          "link": "/government/publications/phonics-self-assessment-form-songbirds-phonics",
+          "format": "publication",
+          "public_timestamp": "2013-05-13T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-self-assessment-form-songbirds-phonics",
           "document_type": "edition"
         },
         {
@@ -6841,6 +6830,17 @@
           "es_score": null,
           "_id": "/government/publications/phonics-screening-check-data-collection-2013-guide",
           "document_type": "edition"
+        },
+        {
+          "title": "Phonics screening check data collection 2013: technical specification",
+          "description": "Technical specification for software suppliers defining the scope of the phonics screening check data collection 2013.",
+          "link": "/government/publications/phonics-screening-check-data-collection-2013-technical-specification",
+          "format": "publication",
+          "public_timestamp": "2013-04-13T00:00:00.000+01:00",
+          "index": "government",
+          "es_score": null,
+          "_id": "/government/publications/phonics-screening-check-data-collection-2013-technical-specification",
+          "document_type": "edition"
         }
       ],
       "total": 76,
@@ -6854,6 +6854,7 @@
   },
   "document_metadata": {
     "government/organisations/department-for-education/about": {
+      "document_type": "about",
       "public_updated_at": "2016-02-19T14:00:17.000+00:00",
       "organisations": [
         {
@@ -6881,6 +6882,7 @@
       ]
     },
     "government/organisations/department-for-education/about/complaints-procedure": {
+      "document_type": "complaints_procedure",
       "public_updated_at": "2014-03-31T10:55:59.000+00:00",
       "organisations": [
         {
@@ -6908,20 +6910,13 @@
       ]
     },
     "government/organisations/department-for-education/about/statistics": {
+      "document_type": "statistics",
       "public_updated_at": "2016-09-15T11:02:46.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-07-18T17:26:49Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -6929,12 +6924,21 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "links": {
           }
         }
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara": {
+      "document_type": "manual",
       "public_updated_at": "2016-09-06T14:22:22.000+00:00",
       "organisations": [
         {
@@ -6962,6 +6966,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara": {
+      "document_type": "manual",
       "public_updated_at": "2016-04-25T10:31:52.000+00:00",
       "organisations": [
         {
@@ -6989,6 +6994,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara": {
+      "document_type": "manual",
       "public_updated_at": "2016-03-24T15:24:21.000+00:00",
       "organisations": [
         {
@@ -7016,6 +7022,7 @@
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-1-introduction": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-14T13:56:01.000+00:00",
       "organisations": [
         {
@@ -7043,6 +7050,7 @@
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-2-early-years-foundation-stage-profile": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-14T13:56:02.000+00:00",
       "organisations": [
         {
@@ -7070,6 +7078,7 @@
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-3-moderation": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-14T13:56:02.000+00:00",
       "organisations": [
         {
@@ -7097,6 +7106,7 @@
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-4-reporting-and-using-results": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-14T13:56:02.000+00:00",
       "organisations": [
         {
@@ -7124,6 +7134,7 @@
       ]
     },
     "guidance/2016-early-years-foundation-stage-assessment-and-reporting-arrangements-ara/section-5-legal-requirements-and-responsibilities": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-14T13:56:02.000+00:00",
       "organisations": [
         {
@@ -7151,6 +7162,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-1-introduction": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-26T07:15:28.000+00:00",
       "organisations": [
         {
@@ -7178,6 +7190,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-10-keeping-and-maintaining-records": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-26T07:15:28.000+00:00",
       "organisations": [
         {
@@ -7205,6 +7218,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-11-legal-requirements-and-responsibilities": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7232,6 +7246,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-2-key-changes": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7259,6 +7274,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-3-key-dates": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7286,6 +7302,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriculum-tests": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-26T07:15:28.000+00:00",
       "organisations": [
         {
@@ -7313,6 +7330,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-5-participation-in-tests": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7340,6 +7358,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-6-test-administration": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7367,6 +7386,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-7-phonics-screening-check": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7394,6 +7414,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-8-teacher-assessment": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:05.000+00:00",
       "organisations": [
         {
@@ -7421,6 +7442,7 @@
       ]
     },
     "guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara/section-9-reporting-to-parents": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-26T07:15:28.000+00:00",
       "organisations": [
         {
@@ -7448,6 +7470,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-1-introduction": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-15T15:28:15.000+00:00",
       "organisations": [
         {
@@ -7475,6 +7498,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-10-test-results": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-15T15:28:15.000+00:00",
       "organisations": [
         {
@@ -7502,6 +7526,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-11-reporting-to-parents": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7529,6 +7554,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-12-keeping-and-maintaining-records": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-15T15:28:15.000+00:00",
       "organisations": [
         {
@@ -7556,6 +7582,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-13-legal-requirements-and-responsibilities": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7583,6 +7610,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-2-key-changes": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7610,6 +7638,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-3-key-dates": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7637,6 +7666,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-4-2016-national-curriulum-tests": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7664,6 +7694,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-5-participation-in-the-tests": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7691,6 +7722,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-6-test-administration": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7718,6 +7750,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-7-monitoring-the-tests": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7745,6 +7778,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-8-science-sampling": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-01-15T15:28:15.000+00:00",
       "organisations": [
         {
@@ -7772,6 +7806,7 @@
       ]
     },
     "guidance/2016-key-stage-2-assessment-and-reporting-arrangements-ara/section-9-teacher-assessment": {
+      "document_type": "manual_section",
       "public_updated_at": "2016-03-24T16:15:44.000+00:00",
       "organisations": [
         {
@@ -7799,6 +7834,7 @@
       ]
     },
     "government/statistics/announcements/early-years-foundation-stage-profile-results-2015-to-2016-additional-tables-containing-characteristic-breakdowns": {
+      "document_type": "national",
       "public_updated_at": "2016-09-20T14:23:05.000+00:00",
       "organisations": [
         {
@@ -7826,6 +7862,7 @@
       ]
     },
     "government/statistics/announcements/early-years-foundation-stage-profile-results-in-england-2015-to-2016": {
+      "document_type": "national",
       "public_updated_at": "2016-05-26T08:55:10.000+00:00",
       "organisations": [
         {
@@ -7853,6 +7890,7 @@
       ]
     },
     "government/statistics/announcements/eyfsp-attainment-by-pupil-characteristics-england-2015": {
+      "document_type": "statistics_announcement",
       "public_updated_at": "2015-10-21T12:54:36.000+00:00",
       "organisations": [
         {
@@ -7880,6 +7918,7 @@
       ]
     },
     "government/consultations/new-national-curriculum-primary-assessment-and-accountability": {
+      "document_type": "consultation_outcome",
       "public_updated_at": "2014-03-27T09:30:17.000+00:00",
       "organisations": [
         {
@@ -7907,6 +7946,7 @@
       ]
     },
     "government/consultations/paediatric-first-aid-eyfs-statutory-framework-amendments": {
+      "document_type": "consultation_outcome",
       "public_updated_at": "2016-07-01T08:32:53.000+00:00",
       "organisations": [
         {
@@ -7934,6 +7974,7 @@
       ]
     },
     "government/consultations/performance-descriptors-key-stages-1-and-2": {
+      "document_type": "consultation_outcome",
       "public_updated_at": "2015-02-26T09:30:28.000+00:00",
       "organisations": [
         {
@@ -7961,20 +8002,13 @@
       ]
     },
     "guidance/awarding-organisations-understanding-our-regulatory-requirements": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2015-12-02T13:43:09.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D109",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/ofqual",
-          "base_path": "/government/organisations/ofqual",
           "content_id": "83f6e93f-bb2c-46ab-9b02-394f972b7030",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-09-07T10:35:47Z",
-          "schema_name": "placeholder",
-          "title": "Ofqual",
-          "web_url": "https://www.gov.uk/government/organisations/ofqual",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -7982,26 +8016,27 @@
               "crest": null
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-07T10:35:47Z",
+          "schema_name": "placeholder",
+          "title": "Ofqual",
+          "base_path": "/government/organisations/ofqual",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/ofqual",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/ofqual",
           "links": {
           }
         }
       ]
     },
     "guidance/early-years-foundation-stage-profile": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-05-20T10:45:42.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-07-18T17:26:49Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8009,26 +8044,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/department-for-education",
           "links": {
           }
         }
       ]
     },
     "guidance/introduction-of-statutory-participation-in-trialling-of-national-curriculum-tests-from-2016": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2015-09-29T09:15:12.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8036,26 +8072,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-and-2-school-visits-following-an-allegation-of-maladministration": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-04-29T15:07:30.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8063,26 +8100,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-and-key-stage-2-test-dates": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-09-06T14:13:52.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8090,26 +8128,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-assessments": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-06-13T11:35:59.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-07-18T17:26:49Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8117,26 +8156,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/department-for-education",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-codes-for-reporting-teacher-assessment-in-2016": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-05-25T09:52:00.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8144,26 +8184,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-tests-how-to-use-access-arrangements": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-03-18T13:56:45.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8171,26 +8212,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-1-tests-standard-setting": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-06-03T11:22:41.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8198,26 +8240,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-and-phonics-screening-check-monitoring-visits": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-04-11T15:20:21.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8225,26 +8268,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-applying-special-consideration-to-results": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-07-04T23:02:00.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8252,26 +8296,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-guide-to-registering-pupils-for-the-tests": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-02-19T17:53:54.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8279,26 +8324,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-access-results-and-test-scripts": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2015-05-21T14:40:29.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8306,26 +8352,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-apply-for-a-review-of-key-stage-2-results": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-06-10T15:43:22.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8333,26 +8380,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-apply-for-a-timetable-variation": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-02-12T17:40:44.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8360,26 +8408,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-apply-for-special-consideration": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-05-06T16:07:04.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8387,26 +8436,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-become-a-marker": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2014-06-12T10:35:45.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8414,26 +8464,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-carry-out-a-monitoring-visit": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-04-11T15:19:14.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8441,26 +8492,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-how-to-use-access-arrangements": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-02-12T17:29:43.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8468,26 +8520,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/key-stage-2-tests-what-to-do-if-a-child-cheats": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-05-09T15:34:30.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8495,26 +8548,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/national-curriculum-assessments-reporting-maladministration": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2014-04-15T23:00:00.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8522,26 +8576,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/national-curriculum-tests-how-independent-schools-can-order-test-materials": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2014-10-31T10:44:36.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8549,26 +8604,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/national-curriculum-tests-how-maintained-schools-can-order-test-materials": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2014-10-31T10:39:40.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8576,26 +8632,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/phonics-screening-check-data-collection": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-06-13T09:12:39.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-07-18T17:26:49Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8603,26 +8660,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/department-for-education",
           "links": {
           }
         }
       ]
     },
     "guidance/phonics-screening-check-how-to-carry-out-a-monitoring-visit": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-04-11T15:24:17.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8630,48 +8688,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/reception-baseline-assessment-guide-to-signing-up-your-school": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-04-14T13:16:05.000+00:00",
       "organisations": [
         {
-          "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
-          "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
-          "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
-          "details": {
-            "brand": "department-for-education",
-            "logo": {
-              "formatted_title": "Standards<br/>&amp; Testing<br/>Agency",
-              "crest": "single-identity"
-            }
-          },
-          "links": {
-          }
-        },
-        {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-07-18T17:26:49Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8679,26 +8716,49 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/department-for-education",
+          "links": {
+          }
+        },
+        {
+          "analytics_identifier": "EA243",
+          "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
+          "description": null,
+          "details": {
+            "brand": "department-for-education",
+            "logo": {
+              "formatted_title": "Standards<br/>&amp; Testing<br/>Agency",
+              "crest": "single-identity"
+            }
+          },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/scaled-scores-at-key-stage-1": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-06-03T11:26:00.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8706,26 +8766,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/scaled-scores-at-key-stage-2": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2016-07-04T23:01:00.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8733,26 +8794,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/teacher-assessment-how-to-use-the-nca-tools-website": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2015-05-13T13:53:39.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8760,26 +8822,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/teacher-assessment-key-stage-1-tasks-and-tests": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2014-10-13T14:36:03.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8787,26 +8850,27 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "guidance/teacher-assessment-submit-teacher-assessment": {
+      "document_type": "detailed_guide",
       "public_updated_at": "2015-05-13T13:31:48.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "EA243",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/standards-and-testing-agency",
-          "base_path": "/government/organisations/standards-and-testing-agency",
           "content_id": "863ffacd-d313-49c1-b856-58fe0799fd41",
           "description": null,
-          "document_type": "placeholder_organisation",
-          "locale": "en",
-          "public_updated_at": "2014-10-15T14:35:54Z",
-          "schema_name": "placeholder_organisation",
-          "title": "Standards and Testing Agency",
-          "web_url": "https://www.gov.uk/government/organisations/standards-and-testing-agency",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8814,12 +8878,21 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "placeholder_organisation",
+          "public_updated_at": "2014-10-15T14:35:54Z",
+          "schema_name": "placeholder_organisation",
+          "title": "Standards and Testing Agency",
+          "base_path": "/government/organisations/standards-and-testing-agency",
+          "locale": "en",
+          "api_url": "https://www-origin.staging.publishing.service.gov.uk/api/content/government/organisations/standards-and-testing-agency",
+          "web_url": "https://www-origin.staging.publishing.service.gov.uk/government/organisations/standards-and-testing-agency",
           "links": {
           }
         }
       ]
     },
     "government/collections/2016-assessment-and-reporting-arrangements": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-10-12T15:53:57.000+00:00",
       "organisations": [
         {
@@ -8847,20 +8920,13 @@
       ]
     },
     "government/collections/departmental-advice-schools": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-07-23T08:30:08.000+00:00",
       "organisations": [
         {
           "analytics_identifier": "D6",
-          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
-          "base_path": "/government/organisations/department-for-education",
           "content_id": "ebd15ade-73b2-4eaf-b1c3-43034a42eb37",
           "description": null,
-          "document_type": "organisation",
-          "locale": "en",
-          "public_updated_at": "2016-09-23T09:06:42Z",
-          "schema_name": "placeholder",
-          "title": "Department for Education",
-          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "details": {
             "brand": "department-for-education",
             "logo": {
@@ -8868,12 +8934,21 @@
               "crest": "single-identity"
             }
           },
+          "document_type": "organisation",
+          "public_updated_at": "2016-09-23T09:06:42Z",
+          "schema_name": "placeholder",
+          "title": "Department for Education",
+          "base_path": "/government/organisations/department-for-education",
+          "locale": "en",
+          "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-education",
+          "web_url": "https://www.gov.uk/government/organisations/department-for-education",
           "links": {
           }
         }
       ]
     },
     "government/collections/early-years-foundation-stage-profile-return": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-02-01T11:50:03.000+00:00",
       "organisations": [
         {
@@ -8901,6 +8976,7 @@
       ]
     },
     "government/collections/key-stage-1-assessments-data-collection": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-02-12T17:12:00.000+00:00",
       "organisations": [
         {
@@ -8928,6 +9004,7 @@
       ]
     },
     "government/collections/key-stage-2-ks2-testing-review": {
+      "document_type": "document_collection",
       "public_updated_at": "2011-06-23T00:00:00.000+00:00",
       "organisations": [
         {
@@ -8955,6 +9032,7 @@
       ]
     },
     "government/collections/maladministration-reports": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-05-09T15:16:28.000+00:00",
       "organisations": [
         {
@@ -8982,6 +9060,7 @@
       ]
     },
     "government/collections/national-curriculum-assessments-guidance-for-local-authorities": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-04-17T07:00:55.000+00:00",
       "organisations": [
         {
@@ -9031,6 +9110,7 @@
       ]
     },
     "government/collections/national-curriculum-assessments-test-frameworks": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-06-29T18:00:55.000+00:00",
       "organisations": [
         {
@@ -9058,6 +9138,7 @@
       ]
     },
     "government/collections/national-curriculum": {
+      "document_type": "document_collection",
       "public_updated_at": "2014-07-16T09:52:11.000+00:00",
       "organisations": [
         {
@@ -9085,6 +9166,7 @@
       ]
     },
     "government/collections/phonics-choosing-a-programme": {
+      "document_type": "document_collection",
       "public_updated_at": "2014-07-16T14:52:10.000+00:00",
       "organisations": [
         {
@@ -9112,6 +9194,7 @@
       ]
     },
     "government/collections/phonics-screening-check-administration": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-06-27T12:18:25.000+00:00",
       "organisations": [
         {
@@ -9139,6 +9222,7 @@
       ]
     },
     "government/collections/phonics-screening-check-data-collection": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-02-01T13:28:15.000+00:00",
       "organisations": [
         {
@@ -9166,6 +9250,7 @@
       ]
     },
     "government/collections/phonics-screening-check-research": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-06-25T09:01:16.000+00:00",
       "organisations": [
         {
@@ -9193,6 +9278,7 @@
       ]
     },
     "government/collections/phonics-screening-check-technical-reports": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-05-09T15:13:07.000+00:00",
       "organisations": [
         {
@@ -9220,6 +9306,7 @@
       ]
     },
     "government/collections/phonics": {
+      "document_type": "document_collection",
       "public_updated_at": "2014-03-19T15:04:00.000+00:00",
       "organisations": [
         {
@@ -9269,6 +9356,7 @@
       ]
     },
     "government/collections/statistics-early-years-foundation-stage-profile": {
+      "document_type": "document_collection",
       "public_updated_at": "2015-10-21T15:30:40.000+00:00",
       "organisations": [
         {
@@ -9296,6 +9384,7 @@
       ]
     },
     "government/collections/statutory-guidance-schools": {
+      "document_type": "document_collection",
       "public_updated_at": "2016-08-10T13:00:15.000+00:00",
       "organisations": [
         {
@@ -9323,6 +9412,7 @@
       ]
     },
     "government/publications/key-stage-1-and-2-maladministration-investigation-procedures/key-stage-1-and-2-maladministration-investigation-procedures": {
+      "document_type": "html_publication",
       "public_updated_at": "2016-04-26T11:39:31.000+00:00",
       "organisations": [
         {
@@ -9340,6 +9430,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-art-and-design-programmes-of-study/national-curriculum-in-england-art-and-design-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2013-09-12T10:17:15.000+00:00",
       "organisations": [
         {
@@ -9357,6 +9448,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-11-09T15:00:33.000+00:00",
       "organisations": [
         {
@@ -9374,6 +9466,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-design-and-technology-programmes-of-study/national-curriculum-in-england-design-and-technology-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-11-09T15:04:21.000+00:00",
       "organisations": [
         {
@@ -9391,6 +9484,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-english-programmes-of-study/national-curriculum-in-england-english-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-01-21T16:10:09.000+00:00",
       "organisations": [
         {
@@ -9408,6 +9502,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-geography-programmes-of-study/national-curriculum-in-england-geography-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-02-04T12:35:26.000+00:00",
       "organisations": [
         {
@@ -9425,6 +9520,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-history-programmes-of-study/national-curriculum-in-england-history-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-02-04T12:11:44.000+00:00",
       "organisations": [
         {
@@ -9442,6 +9538,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-languages-progammes-of-study/national-curriculum-in-england-languages-progammes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-02-04T12:09:22.000+00:00",
       "organisations": [
         {
@@ -9459,6 +9556,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-mathematics-programmes-of-study/national-curriculum-in-england-mathematics-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-01-21T16:49:53.000+00:00",
       "organisations": [
         {
@@ -9476,6 +9574,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-music-programmes-of-study/national-curriculum-in-england-music-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-02-04T12:05:27.000+00:00",
       "organisations": [
         {
@@ -9493,6 +9592,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-physical-education-programmes-of-study/national-curriculum-in-england-physical-education-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-02-04T12:00:50.000+00:00",
       "organisations": [
         {
@@ -9510,6 +9610,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-science-programmes-of-study/national-curriculum-in-england-science-programmes-of-study": {
+      "document_type": "html_publication",
       "public_updated_at": "2015-04-27T14:33:49.000+00:00",
       "organisations": [
         {
@@ -9527,6 +9628,7 @@
       ]
     },
     "government/publications/request-about-the-national-curriculum-review/request-about-the-national-curriculum-review": {
+      "document_type": "html_publication",
       "public_updated_at": "2013-04-19T10:22:41.000+00:00",
       "organisations": [
         {
@@ -9544,6 +9646,7 @@
       ]
     },
     "government/news/100000-more-pupils-on-track-to-succeed-in-reading-via-phonics": {
+      "document_type": "press_release",
       "public_updated_at": "2014-09-25T09:43:00.000+00:00",
       "organisations": [
         {
@@ -9571,6 +9674,7 @@
       ]
     },
     "government/news/2016-national-curriculum-tests-sample-materials-now-available": {
+      "document_type": "news_story",
       "public_updated_at": "2014-07-14T08:30:00.000+00:00",
       "organisations": [
         {
@@ -9598,6 +9702,7 @@
       ]
     },
     "government/news/90000-more-pupils-leaving-primary-with-maths-and-literacy-skills": {
+      "document_type": "press_release",
       "public_updated_at": "2015-08-27T09:25:00.000+00:00",
       "organisations": [
         {
@@ -9625,6 +9730,7 @@
       ]
     },
     "government/news/a-third-of-children-reach-expected-level-in-pilot-of-phonics-check": {
+      "document_type": "news_story",
       "public_updated_at": "2011-12-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -9652,6 +9758,7 @@
       ]
     },
     "government/news/assessment-updates-for-schools": {
+      "document_type": "news_story",
       "public_updated_at": "2015-03-19T11:40:00.000+00:00",
       "organisations": [
         {
@@ -9679,6 +9786,7 @@
       ]
     },
     "government/news/assessment-without-levels-commission-announced": {
+      "document_type": "press_release",
       "public_updated_at": "2015-02-25T16:41:00.000+00:00",
       "organisations": [
         {
@@ -9706,6 +9814,7 @@
       ]
     },
     "government/news/call-for-evidence-for-the-review-of-the-early-years-foundation-stage": {
+      "document_type": "news_story",
       "public_updated_at": "2010-08-02T00:00:00.000+00:00",
       "organisations": [
         {
@@ -9733,6 +9842,7 @@
       ]
     },
     "government/news/clarification-key-stage-1-and-2-teacher-assessment-and-moderation-guidance": {
+      "document_type": "news_story",
       "public_updated_at": "2016-03-08T17:35:01.000+00:00",
       "organisations": [
         {
@@ -9760,6 +9870,7 @@
       ]
     },
     "government/news/dame-clare-tickell-responds-to-inaccurate-reports-about-her-review-of-the-eyfs": {
+      "document_type": "government_response",
       "public_updated_at": "2011-04-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -9787,6 +9898,7 @@
       ]
     },
     "government/news/department-for-education-spending-review": {
+      "document_type": "press_release",
       "public_updated_at": "2010-10-19T23:00:00.000+00:00",
       "organisations": [
         {
@@ -9814,6 +9926,7 @@
       ]
     },
     "government/news/early-years-foundation-stage-to-be-radically-slimmed-down": {
+      "document_type": "press_release",
       "public_updated_at": "2011-03-29T23:00:00.000+00:00",
       "organisations": [
         {
@@ -9841,6 +9954,7 @@
       ]
     },
     "government/news/education-bill-receives-royal-assent": {
+      "document_type": "press_release",
       "public_updated_at": "2011-11-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -9868,6 +9982,7 @@
       ]
     },
     "government/news/education-reform-a-world-class-curriculum-to-drive-up-standards-and-fuel-aspiration": {
+      "document_type": "news_story",
       "public_updated_at": "2013-07-08T09:59:00.000+00:00",
       "organisations": [
         {
@@ -9917,6 +10032,7 @@
       ]
     },
     "government/news/elite-teachers-travel-from-shanghai-for-pioneering-maths-exchange": {
+      "document_type": "press_release",
       "public_updated_at": "2014-11-04T11:35:00.000+00:00",
       "organisations": [
         {
@@ -9944,6 +10060,7 @@
       ]
     },
     "government/news/focus-on-phonics-vindicated-by-results": {
+      "document_type": "press_release",
       "public_updated_at": "2015-09-24T09:09:21.000+00:00",
       "organisations": [
         {
@@ -9971,6 +10088,7 @@
       ]
     },
     "government/news/funding-for-phonics-teaching-to-improve-childrens-reading": {
+      "document_type": "press_release",
       "public_updated_at": "2011-04-06T00:00:00.000+00:00",
       "organisations": [
         {
@@ -9998,6 +10116,7 @@
       ]
     },
     "government/news/gove-to-the-national-college-we-have-to-make-opportunity-more-equal": {
+      "document_type": "news_story",
       "public_updated_at": "2010-06-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10025,6 +10144,7 @@
       ]
     },
     "government/news/government-response-to-lord-bew-key-stage-2-review-published": {
+      "document_type": "government_response",
       "public_updated_at": "2011-07-17T23:00:00.000+00:00",
       "organisations": [
         {
@@ -10052,6 +10172,7 @@
       ]
     },
     "government/news/harmful-ict-curriculum-set-to-be-dropped-to-make-way-for-rigorous-computer-science": {
+      "document_type": "press_release",
       "public_updated_at": "2012-01-11T01:00:00.000+00:00",
       "organisations": [
         {
@@ -10079,6 +10200,7 @@
       ]
     },
     "government/news/introduction-of-a-new-methodology-for-measuring-attainment-in-key-stage-2-science-sampling": {
+      "document_type": "news_story",
       "public_updated_at": "2016-01-27T15:11:00.000+00:00",
       "organisations": [
         {
@@ -10106,6 +10228,7 @@
       ]
     },
     "government/news/key-stage-2-achievement-statistics-published": {
+      "document_type": "news_story",
       "public_updated_at": "2010-12-14T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10133,6 +10256,7 @@
       ]
     },
     "government/news/key-stage-2-english-grammar-punctuation-and-spelling-test": {
+      "document_type": "news_story",
       "public_updated_at": "2016-05-10T10:29:00.000+00:00",
       "organisations": [
         {
@@ -10160,6 +10284,7 @@
       ]
     },
     "government/news/key-stage-2-pupil-achievement-figures": {
+      "document_type": "news_story",
       "public_updated_at": "2010-12-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10187,6 +10312,7 @@
       ]
     },
     "government/news/key-stage-2-results": {
+      "document_type": "news_story",
       "public_updated_at": "2010-08-03T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10214,6 +10340,7 @@
       ]
     },
     "government/news/key-stage-2-science-sample-test-results-published": {
+      "document_type": "news_story",
       "public_updated_at": "2010-08-10T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10241,6 +10368,7 @@
       ]
     },
     "government/news/key-stage-2-test-results-published--2": {
+      "document_type": "press_release",
       "public_updated_at": "2011-08-02T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10268,6 +10396,7 @@
       ]
     },
     "government/news/key-stage-2-test-results-published": {
+      "document_type": "press_release",
       "public_updated_at": "2012-09-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10295,6 +10424,7 @@
       ]
     },
     "government/news/key-stage-2-test-results-released": {
+      "document_type": "news_story",
       "public_updated_at": "2010-07-06T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10322,6 +10452,7 @@
       ]
     },
     "government/news/members-of-new-commission-on-assessment-without-levels-announced": {
+      "document_type": "news_story",
       "public_updated_at": "2015-03-09T15:29:00.000+00:00",
       "organisations": [
         {
@@ -10349,6 +10480,7 @@
       ]
     },
     "government/news/michael-gove-announces-review-of-key-stage-2-testing": {
+      "document_type": "news_story",
       "public_updated_at": "2010-11-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10376,6 +10508,7 @@
       ]
     },
     "government/news/michael-gove-responds-to-the-daily-telegraph-investigation": {
+      "document_type": "news_story",
       "public_updated_at": "2011-12-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10403,6 +10536,7 @@
       ]
     },
     "government/news/national-curriculum-review-launched": {
+      "document_type": "press_release",
       "public_updated_at": "2011-01-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10430,6 +10564,7 @@
       ]
     },
     "government/news/nca-tools-test-orders-section-closes-this-friday": {
+      "document_type": "news_story",
       "public_updated_at": "2014-11-25T09:03:00.000+00:00",
       "organisations": [
         {
@@ -10457,6 +10592,7 @@
       ]
     },
     "government/news/nca-tools-test-orders-section-is-open": {
+      "document_type": "news_story",
       "public_updated_at": "2014-09-29T08:00:00.000+00:00",
       "organisations": [
         {
@@ -10484,6 +10620,7 @@
       ]
     },
     "government/news/new-curriculum-will-make-education-system-envy-of-the-world": {
+      "document_type": "press_release",
       "public_updated_at": "2014-09-04T14:48:00.000+00:00",
       "organisations": [
         {
@@ -10511,6 +10648,7 @@
       ]
     },
     "government/news/new-early-years-framework-published": {
+      "document_type": "press_release",
       "public_updated_at": "2012-03-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10538,6 +10676,7 @@
       ]
     },
     "government/news/new-phonics-check-will-identify-thousands-of-children-needing-extra-reading-help": {
+      "document_type": "news_story",
       "public_updated_at": "2011-09-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10565,6 +10704,7 @@
       ]
     },
     "government/news/new-primary-curriculum-to-bring-higher-standards-in-english-maths-and-science": {
+      "document_type": "press_release",
       "public_updated_at": "2012-06-11T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10592,6 +10732,7 @@
       ]
     },
     "government/news/new-primary-school-tests-will-help-eradicate-illiteracy-and-innumeracy": {
+      "document_type": "press_release",
       "public_updated_at": "2014-07-14T15:45:00.000+00:00",
       "organisations": [
         {
@@ -10619,6 +10760,7 @@
       ]
     },
     "government/news/new-video-published-on-changes-to-2016-tests-and-assessments": {
+      "document_type": "news_story",
       "public_updated_at": "2015-09-09T11:19:43.000+00:00",
       "organisations": [
         {
@@ -10646,6 +10788,7 @@
       ]
     },
     "government/news/new-year-honours-list-2015-education-and-childrens-services": {
+      "document_type": "news_story",
       "public_updated_at": "2014-12-31T10:00:00.000+00:00",
       "organisations": [
         {
@@ -10673,6 +10816,7 @@
       ]
     },
     "government/news/nick-gibb-congratulates-teachers-and-pupils-on-their-hard-work-in-key-stage-1": {
+      "document_type": "news_story",
       "public_updated_at": "2010-08-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10700,6 +10844,7 @@
       ]
     },
     "government/news/nicky-morgan-and-david-walliams-launch-literacy-drive": {
+      "document_type": "press_release",
       "public_updated_at": "2015-09-24T08:59:00.000+00:00",
       "organisations": [
         {
@@ -10727,6 +10872,7 @@
       ]
     },
     "government/news/ofqual-report-to-parliament": {
+      "document_type": "news_story",
       "public_updated_at": "2015-02-12T11:33:00.000+00:00",
       "organisations": [
         {
@@ -10754,6 +10900,7 @@
       ]
     },
     "government/news/ofsted-chief-inspector-calls-for-rapid-improvement-in-literacy": {
+      "document_type": "press_release",
       "public_updated_at": "2012-03-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10781,6 +10928,7 @@
       ]
     },
     "government/news/ofsted-updates-school-data-dashboard-with-2013-results": {
+      "document_type": "press_release",
       "public_updated_at": "2014-03-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10808,6 +10956,7 @@
       ]
     },
     "government/news/overwhelming-support-for-foreign-languages-plan": {
+      "document_type": "press_release",
       "public_updated_at": "2012-11-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10835,6 +10984,7 @@
       ]
     },
     "government/news/phonics-check-and-key-stage-1-results": {
+      "document_type": "press_release",
       "public_updated_at": "2013-10-03T10:12:02.000+00:00",
       "organisations": [
         {
@@ -10862,6 +11012,7 @@
       ]
     },
     "government/news/phonics-funding-thousands-of-schools-sign-up": {
+      "document_type": "press_release",
       "public_updated_at": "2012-01-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10889,6 +11040,7 @@
       ]
     },
     "government/news/phonics-reading-check-and-key-stage-1-results-published": {
+      "document_type": "press_release",
       "public_updated_at": "2012-09-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10916,6 +11068,7 @@
       ]
     },
     "government/news/phonics-screening-check-threshold-published-today": {
+      "document_type": "news_story",
       "public_updated_at": "2014-06-30T09:13:00.000+00:00",
       "organisations": [
         {
@@ -10943,6 +11096,7 @@
       ]
     },
     "government/news/phonics-screening-check-week-begins-today": {
+      "document_type": "news_story",
       "public_updated_at": "2014-06-16T07:00:00.000+00:00",
       "organisations": [
         {
@@ -10970,6 +11124,7 @@
       ]
     },
     "government/news/primary-schools-test-results-released--2": {
+      "document_type": "press_release",
       "public_updated_at": "2011-12-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -10997,6 +11152,7 @@
       ]
     },
     "government/news/primary-schools-test-results-released": {
+      "document_type": "press_release",
       "public_updated_at": "2012-12-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11024,6 +11180,7 @@
       ]
     },
     "government/news/primary-test-results-standards-rising-in-all-subjects": {
+      "document_type": "press_release",
       "public_updated_at": "2014-08-28T11:20:01.000+00:00",
       "organisations": [
         {
@@ -11051,6 +11208,7 @@
       ]
     },
     "government/news/primary-testing-and-assessment-webinar-registration-still-open": {
+      "document_type": "news_story",
       "public_updated_at": "2015-11-18T13:28:42.000+00:00",
       "organisations": [
         {
@@ -11078,6 +11236,7 @@
       ]
     },
     "government/news/quality-nurseries-urged-to-make-full-use-of-flexibility": {
+      "document_type": "press_release",
       "public_updated_at": "2013-04-18T23:00:00.000+00:00",
       "organisations": [
         {
@@ -11105,6 +11264,7 @@
       ]
     },
     "government/news/queens-birthday-honours-2014-education-and-childrens-services": {
+      "document_type": "news_story",
       "public_updated_at": "2014-06-13T23:15:00.000+00:00",
       "organisations": [
         {
@@ -11132,6 +11292,7 @@
       ]
     },
     "government/news/queens-birthday-honours-2015-education-and-childrens-services": {
+      "document_type": "news_story",
       "public_updated_at": "2015-06-12T22:00:00.000+00:00",
       "organisations": [
         {
@@ -11159,6 +11320,7 @@
       ]
     },
     "government/news/queens-birthday-honours-recipients-announced": {
+      "document_type": "news_story",
       "public_updated_at": "2013-06-16T23:00:00.000+00:00",
       "organisations": [
         {
@@ -11186,6 +11348,7 @@
       ]
     },
     "government/news/reading-at-an-early-age-the-key-to-success": {
+      "document_type": "press_release",
       "public_updated_at": "2010-11-22T01:00:00.000+00:00",
       "organisations": [
         {
@@ -11213,6 +11376,7 @@
       ]
     },
     "government/news/reception-baseline-comparability-study-published": {
+      "document_type": "press_release",
       "public_updated_at": "2016-04-07T15:51:00.000+00:00",
       "organisations": [
         {
@@ -11262,6 +11426,7 @@
       ]
     },
     "government/news/register-now-for-primary-assessment-webinars": {
+      "document_type": "news_story",
       "public_updated_at": "2016-02-18T15:03:08.000+00:00",
       "organisations": [
         {
@@ -11289,6 +11454,7 @@
       ]
     },
     "government/news/review-of-early-years-foundation-stage": {
+      "document_type": "news_story",
       "public_updated_at": "2010-07-06T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11316,6 +11482,7 @@
       ]
     },
     "government/news/revised-early-years-foundation-stage-consultation-closes-30-september": {
+      "document_type": "news_story",
       "public_updated_at": "2011-10-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11343,6 +11510,7 @@
       ]
     },
     "government/news/sample-test-material-for-2016-national-curriculum-tests-published": {
+      "document_type": "news_story",
       "public_updated_at": "2015-06-30T08:45:59.000+00:00",
       "organisations": [
         {
@@ -11370,6 +11538,7 @@
       ]
     },
     "government/news/second-phase-of-pioneering-shanghai-maths-teacher-exchange-begins": {
+      "document_type": "press_release",
       "public_updated_at": "2015-02-23T15:52:40.000+00:00",
       "organisations": [
         {
@@ -11397,6 +11566,7 @@
       ]
     },
     "government/news/setting-research-priorities-in-education-and-childrens-services": {
+      "document_type": "news_story",
       "public_updated_at": "2014-03-13T09:39:00.000+00:00",
       "organisations": [
         {
@@ -11424,6 +11594,7 @@
       ]
     },
     "government/news/statement-from-schools-minister-nick-gibb-on-ofquals-monitoring-report-of-the-2009-key-stage-2-tests": {
+      "document_type": "news_story",
       "public_updated_at": "2010-07-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11451,6 +11622,7 @@
       ]
     },
     "government/news/statement-from-sta-about-key-stage-1-tests": {
+      "document_type": "press_release",
       "public_updated_at": "2016-04-22T09:22:41.000+00:00",
       "organisations": [
         {
@@ -11478,6 +11650,7 @@
       ]
     },
     "government/news/teaching-the-new-computing-curriculum": {
+      "document_type": "press_release",
       "public_updated_at": "2013-12-04T13:28:00.000+00:00",
       "organisations": [
         {
@@ -11505,6 +11678,7 @@
       ]
     },
     "government/news/the-department-for-educations-response-to-public-comments-on-the-coalition-agreement-on-schools": {
+      "document_type": "government_response",
       "public_updated_at": "2010-07-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11532,6 +11706,7 @@
       ]
     },
     "government/news/the-school-revolution-how-reforms-are-transforming-schools": {
+      "document_type": "press_release",
       "public_updated_at": "2014-07-10T17:24:00.000+00:00",
       "organisations": [
         {
@@ -11559,6 +11734,7 @@
       ]
     },
     "government/news/thousands-of-pupils-to-visit-first-world-war-battlefields": {
+      "document_type": "press_release",
       "public_updated_at": "2013-10-21T09:34:00.000+00:00",
       "organisations": [
         {
@@ -11630,6 +11806,7 @@
       ]
     },
     "government/news/use-of-calculators-in-primary-schools-to-be-reviewed": {
+      "document_type": "news_story",
       "public_updated_at": "2011-12-02T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11657,14 +11834,17 @@
       ]
     },
     "government/organisations/qualifications-and-curriculum-authority": {
+      "document_type": "placeholder_organisation",
       "public_updated_at": "2014-10-15T14:37:03.000+00:00",
       "organisations": null
     },
     "government/organisations/sutherland-inquiry": {
+      "document_type": "placeholder_organisation",
       "public_updated_at": "2014-10-15T14:38:11.000+00:00",
       "organisations": null
     },
     "government/publications/2012-maladministration-investigation-procedures": {
+      "document_type": "policy_paper",
       "public_updated_at": "2012-10-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -11692,6 +11872,7 @@
       ]
     },
     "government/publications/2012-maladministration-report": {
+      "document_type": "research",
       "public_updated_at": "2013-08-22T09:23:38.000+00:00",
       "organisations": [
         {
@@ -11741,6 +11922,7 @@
       ]
     },
     "government/publications/2013-maladministration-report": {
+      "document_type": "research",
       "public_updated_at": "2014-11-27T14:48:27.000+00:00",
       "organisations": [
         {
@@ -11768,6 +11950,7 @@
       ]
     },
     "government/publications/2014-maladministration-report": {
+      "document_type": "research",
       "public_updated_at": "2015-12-17T07:38:17.000+00:00",
       "organisations": [
         {
@@ -11795,6 +11978,7 @@
       ]
     },
     "government/publications/2016-assessment-and-reporting-arrangements-pdf-format-versions": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2016-04-25T16:02:26.000+00:00",
       "organisations": [
         {
@@ -11822,6 +12006,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-26T09:53:26.000+00:00",
       "organisations": [
         {
@@ -11849,6 +12034,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-sample-test-materials-mark-scheme-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-30T14:45:27.000+00:00",
       "organisations": [
         {
@@ -11876,6 +12062,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T16:01:07.000+00:00",
       "organisations": [
         {
@@ -11903,6 +12090,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-reading-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-01-26T14:24:04.000+00:00",
       "organisations": [
         {
@@ -11930,6 +12118,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-reading-sample-test-materials-mark-scheme-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-30T14:44:33.000+00:00",
       "organisations": [
         {
@@ -11957,6 +12146,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-english-reading-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:30:00.000+00:00",
       "organisations": [
         {
@@ -11984,6 +12174,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-mathematics-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-01-26T14:23:01.000+00:00",
       "organisations": [
         {
@@ -12011,6 +12202,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-mathematics-sample-test-materials-mark-schemes-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-02-19T15:09:29.000+00:00",
       "organisations": [
         {
@@ -12038,6 +12230,7 @@
       ]
     },
     "government/publications/2016-key-stage-1-mathematics-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:45:00.000+00:00",
       "organisations": [
         {
@@ -12065,6 +12258,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-01-26T14:20:26.000+00:00",
       "organisations": [
         {
@@ -12092,6 +12286,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-sample-test-materials-mark-scheme-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-30T14:47:34.000+00:00",
       "organisations": [
         {
@@ -12119,6 +12314,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-grammar-punctuation-and-spelling-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:44:00.000+00:00",
       "organisations": [
         {
@@ -12146,6 +12342,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-reading-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-01-26T14:19:15.000+00:00",
       "organisations": [
         {
@@ -12173,6 +12370,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-reading-sample-test-materials-mark-scheme-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-30T14:47:02.000+00:00",
       "organisations": [
         {
@@ -12200,6 +12398,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-english-reading-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:46:00.000+00:00",
       "organisations": [
         {
@@ -12227,6 +12426,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-mathematics-sample-modified-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-01-26T14:25:14.000+00:00",
       "organisations": [
         {
@@ -12254,6 +12454,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-mathematics-sample-test-materials-mark-schemes-and-test-administration-instructions": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-30T14:44:00.000+00:00",
       "organisations": [
         {
@@ -12281,6 +12482,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-mathematics-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:47:00.000+00:00",
       "organisations": [
         {
@@ -12308,6 +12510,7 @@
       ]
     },
     "government/publications/2016-key-stage-2-science-sampling-test-sample-questions-mark-scheme-and-commentary": {
+      "document_type": "guidance",
       "public_updated_at": "2014-07-14T08:48:47.000+00:00",
       "organisations": [
         {
@@ -12335,6 +12538,7 @@
       ]
     },
     "government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents": {
+      "document_type": "promotional",
       "public_updated_at": "2016-05-03T13:00:00.000+00:00",
       "organisations": [
         {
@@ -12362,6 +12566,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks1-english-reading": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T13:01:00.000+00:00",
       "organisations": [
         {
@@ -12389,6 +12594,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks1-english-writing": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T16:39:17.000+00:00",
       "organisations": [
         {
@@ -12416,6 +12622,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks1-mathematics": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T12:53:17.000+00:00",
       "organisations": [
         {
@@ -12443,6 +12650,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks1-science": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T12:58:00.000+00:00",
       "organisations": [
         {
@@ -12470,6 +12678,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks2-english-reading": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T13:00:51.000+00:00",
       "organisations": [
         {
@@ -12497,6 +12706,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks2-english-writing": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T16:34:53.000+00:00",
       "organisations": [
         {
@@ -12524,6 +12734,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks2-mathematics": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T15:46:31.000+00:00",
       "organisations": [
         {
@@ -12551,6 +12762,7 @@
       ]
     },
     "government/publications/2016-teacher-assessment-exemplification-ks2-science": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T12:59:25.000+00:00",
       "organisations": [
         {
@@ -12578,6 +12790,7 @@
       ]
     },
     "government/publications/a-curriculum-for-impressive-school-improvement": {
+      "document_type": "research",
       "public_updated_at": "2012-09-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12605,6 +12818,7 @@
       ]
     },
     "government/publications/a-fully-inclusive-environment-that-enhances-learning": {
+      "document_type": "research",
       "public_updated_at": "2012-03-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12632,6 +12846,7 @@
       ]
     },
     "government/publications/a-whole-school-approach-to-art-craft-and-design": {
+      "document_type": "research",
       "public_updated_at": "2014-01-06T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12659,6 +12874,7 @@
       ]
     },
     "government/publications/achievement-of-children-in-the-early-years-foundation-stage-profile": {
+      "document_type": "research",
       "public_updated_at": "2010-09-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12686,6 +12902,7 @@
       ]
     },
     "government/publications/an-innovative-approach-to-observing-and-assessing-learning-and-development": {
+      "document_type": "research",
       "public_updated_at": "2012-02-21T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12713,6 +12930,7 @@
       ]
     },
     "government/publications/an-innovative-approach-to-personalised-learning": {
+      "document_type": "research",
       "public_updated_at": "2012-02-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12740,6 +12958,7 @@
       ]
     },
     "government/publications/an-investigation-of-key-stage-2-access-arrangements-procedures": {
+      "document_type": "research",
       "public_updated_at": "2013-05-23T03:21:00.000+00:00",
       "organisations": [
         {
@@ -12767,6 +12986,7 @@
       ]
     },
     "government/publications/art-craft-and-design-education-making-a-mark": {
+      "document_type": "research",
       "public_updated_at": "2012-03-29T23:00:00.000+00:00",
       "organisations": [
         {
@@ -12794,6 +13014,7 @@
       ]
     },
     "government/publications/assessment-framework-for-the-development-of-the-year-1-phonics-screening-check": {
+      "document_type": "guidance",
       "public_updated_at": "2012-02-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12843,6 +13064,7 @@
       ]
     },
     "government/publications/assessment-principles-school-curriculum": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-16T14:51:00.000+00:00",
       "organisations": [
         {
@@ -12870,6 +13092,7 @@
       ]
     },
     "government/publications/assessment-reliability-an-introduction": {
+      "document_type": "research",
       "public_updated_at": "2013-05-15T23:00:00.000+00:00",
       "organisations": [
         {
@@ -12897,6 +13120,7 @@
       ]
     },
     "government/publications/bringing-together-the-early-years-foundation-stage-and-the-national-curriculum": {
+      "document_type": "research",
       "public_updated_at": "2012-11-12T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12924,6 +13148,7 @@
       ]
     },
     "government/publications/childrens-experiences-of-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2010-12-23T00:00:00.000+00:00",
       "organisations": [
         {
@@ -12951,6 +13176,7 @@
       ]
     },
     "government/publications/classification-accuracy-in-key-stage-2-test-results": {
+      "document_type": "research",
       "public_updated_at": "2013-05-15T23:00:00.000+00:00",
       "organisations": [
         {
@@ -12978,6 +13204,7 @@
       ]
     },
     "government/publications/closing-the-gap-with-the-new-primary-national-curriculum": {
+      "document_type": "research",
       "public_updated_at": "2014-09-01T11:24:00.000+00:00",
       "organisations": [
         {
@@ -13005,6 +13232,7 @@
       ]
     },
     "government/publications/collaborating-to-support-early-years-teaching-and-learning": {
+      "document_type": "research",
       "public_updated_at": "2015-07-13T09:15:00.000+00:00",
       "organisations": [
         {
@@ -13032,6 +13260,7 @@
       ]
     },
     "government/publications/commission-on-assessment-without-levels-final-report": {
+      "document_type": "independent_report",
       "public_updated_at": "2015-09-17T12:45:00.000+00:00",
       "organisations": [
         {
@@ -13081,6 +13310,7 @@
       ]
     },
     "government/publications/commission-on-assessment-without-levels-government-response": {
+      "document_type": "policy_paper",
       "public_updated_at": "2015-09-17T12:49:00.000+00:00",
       "organisations": [
         {
@@ -13130,6 +13360,7 @@
       ]
     },
     "government/publications/cost-of-administering-sats-in-primary-school": {
+      "document_type": "foi_release",
       "public_updated_at": "2014-08-15T09:34:58.000+00:00",
       "organisations": [
         {
@@ -13157,6 +13388,7 @@
       ]
     },
     "government/publications/delivering-early-years-foundation-stage-in-overseas-settings-jsp-819": {
+      "document_type": "guidance",
       "public_updated_at": "2014-08-06T10:24:00.000+00:00",
       "organisations": [
         {
@@ -13184,6 +13416,7 @@
       ]
     },
     "government/publications/department-for-education-annual-report-and-accounts-financial-year-2010-to-2011": {
+      "document_type": "corporate_report",
       "public_updated_at": "2011-07-07T11:39:00.000+00:00",
       "organisations": [
         {
@@ -13211,6 +13444,7 @@
       ]
     },
     "government/publications/department-for-education-independent-review-of-key-stage-2-testing-assessment-and-accountability-july-2011": {
+      "document_type": "policy_paper",
       "public_updated_at": "2011-07-18T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13238,6 +13472,7 @@
       ]
     },
     "government/publications/developing-a-communication-supporting-classrooms-observation-tool": {
+      "document_type": "research",
       "public_updated_at": "2012-12-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13265,6 +13500,7 @@
       ]
     },
     "government/publications/developing-a-relevant-curriculum": {
+      "document_type": "research",
       "public_updated_at": "2013-04-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13292,6 +13528,7 @@
       ]
     },
     "government/publications/developing-environments-to-help-communication-skills": {
+      "document_type": "research",
       "public_updated_at": "2011-11-25T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13319,6 +13556,7 @@
       ]
     },
     "government/publications/developing-outstanding-historical-thinking-in-primary-schools": {
+      "document_type": "research",
       "public_updated_at": "2012-01-10T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13346,6 +13584,7 @@
       ]
     },
     "government/publications/developing-problem-solving-reasoning-and-numeracy-outdoors": {
+      "document_type": "research",
       "public_updated_at": "2012-04-24T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13373,6 +13612,7 @@
       ]
     },
     "government/publications/developing-young-childrens-communication-and-language-skills": {
+      "document_type": "research",
       "public_updated_at": "2013-03-28T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13400,6 +13640,7 @@
       ]
     },
     "government/publications/disapplying-aspects-of-the-national-curriculum": {
+      "document_type": "guidance",
       "public_updated_at": "2006-06-30T23:00:00.000+00:00",
       "organisations": [
         {
@@ -13427,6 +13668,7 @@
       ]
     },
     "government/publications/early-language-and-literacy-from-training-to-teaching": {
+      "document_type": "research",
       "public_updated_at": "2012-11-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13454,6 +13696,7 @@
       ]
     },
     "government/publications/early-learning-for-two-year-olds-trials": {
+      "document_type": "policy_paper",
       "public_updated_at": "2013-06-12T13:16:00.000+00:00",
       "organisations": [
         {
@@ -13481,6 +13724,7 @@
       ]
     },
     "government/publications/early-years-evidence-pack": {
+      "document_type": "research",
       "public_updated_at": "2011-07-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13508,6 +13752,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-assessment-and-reporting-2014": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-11-15T09:00:00.000+00:00",
       "organisations": [
         {
@@ -13557,6 +13802,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-assessment-and-reporting-arrangements-ara": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2014-09-05T15:39:00.000+00:00",
       "organisations": [
         {
@@ -13606,6 +13852,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-profile-2012-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2012-04-23T23:00:00.000+00:00",
       "organisations": [
         {
@@ -13633,6 +13880,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-profile-2013-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-15T23:00:00.000+00:00",
       "organisations": [
         {
@@ -13660,6 +13908,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-profile-handbook-2014": {
+      "document_type": "guidance",
       "public_updated_at": "2014-09-08T14:07:44.000+00:00",
       "organisations": [
         {
@@ -13709,6 +13958,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-profile-handbook": {
+      "document_type": "guidance",
       "public_updated_at": "2016-09-06T14:12:37.000+00:00",
       "organisations": [
         {
@@ -13736,6 +13986,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-profile-return-2015-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2015-05-27T09:52:08.000+00:00",
       "organisations": [
         {
@@ -13763,6 +14014,7 @@
       ]
     },
     "government/publications/early-years-foundation-stage-to-school-transition-project": {
+      "document_type": "research",
       "public_updated_at": "2012-03-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13790,6 +14042,7 @@
       ]
     },
     "government/publications/effective-collaboration-to-support-childminders-and-parents": {
+      "document_type": "research",
       "public_updated_at": "2012-10-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13817,6 +14070,7 @@
       ]
     },
     "government/publications/effective-ways-for-success-in-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2012-02-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13844,6 +14098,7 @@
       ]
     },
     "government/publications/engaging-parents-in-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2011-07-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13871,6 +14126,7 @@
       ]
     },
     "government/publications/engaging-reception-children-in-phonics": {
+      "document_type": "research",
       "public_updated_at": "2012-02-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13898,6 +14154,7 @@
       ]
     },
     "government/publications/english-grammar-punctuation-and-spelling-2013-technical-report": {
+      "document_type": "research",
       "public_updated_at": "2015-05-29T12:55:58.000+00:00",
       "organisations": [
         {
@@ -13925,6 +14182,7 @@
       ]
     },
     "government/publications/english-programmes-of-study-for-key-stage-1-and-2-until-july-2015": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "1999-09-01T08:00:00.000+00:00",
       "organisations": [
         {
@@ -13952,6 +14210,7 @@
       ]
     },
     "government/publications/evaluation-of-every-child-a-reader-ecar": {
+      "document_type": "research",
       "public_updated_at": "2011-05-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -13979,6 +14238,7 @@
       ]
     },
     "government/publications/evaluation-of-the-phonics-screening-check-first-interim-report": {
+      "document_type": "research",
       "public_updated_at": "2013-05-20T12:45:00.000+00:00",
       "organisations": [
         {
@@ -14006,6 +14266,7 @@
       ]
     },
     "government/publications/excellence-in-english": {
+      "document_type": "research",
       "public_updated_at": "2011-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -14033,6 +14294,7 @@
       ]
     },
     "government/publications/eyfs-profile-2012-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2011-12-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14060,6 +14322,7 @@
       ]
     },
     "government/publications/eyfs-profile-2013-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-06T23:00:00.000+00:00",
       "organisations": [
         {
@@ -14087,6 +14350,7 @@
       ]
     },
     "government/publications/eyfs-profile-exemplication-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2014-10-07T12:27:34.000+00:00",
       "organisations": [
         {
@@ -14136,6 +14400,7 @@
       ]
     },
     "government/publications/eyfsp-2014-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-09T09:21:50.000+00:00",
       "organisations": [
         {
@@ -14163,6 +14428,7 @@
       ]
     },
     "government/publications/eyfsp-2015-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2015-04-17T15:58:17.000+00:00",
       "organisations": [
         {
@@ -14190,6 +14456,7 @@
       ]
     },
     "government/publications/eyfsp-return-2014-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2014-06-23T13:48:42.000+00:00",
       "organisations": [
         {
@@ -14217,6 +14484,7 @@
       ]
     },
     "government/publications/factors-associated-with-achievement-key-stages-2-and-4": {
+      "document_type": "research",
       "public_updated_at": "2015-11-05T10:00:00.000+00:00",
       "organisations": [
         {
@@ -14244,6 +14512,7 @@
       ]
     },
     "government/publications/first-national-survey-of-practitioners-with-early-years-professional-status": {
+      "document_type": "research",
       "public_updated_at": "2011-01-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14271,6 +14540,7 @@
       ]
     },
     "government/publications/food-teaching-in-primary-schools-knowledge-and-skills-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-11-19T14:30:26.000+00:00",
       "organisations": [
         {
@@ -14298,6 +14568,7 @@
       ]
     },
     "government/publications/foundation-learning-national-evaluation": {
+      "document_type": "research",
       "public_updated_at": "2011-06-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14325,6 +14596,7 @@
       ]
     },
     "government/publications/geography-learning-to-make-a-world-of-difference": {
+      "document_type": "research",
       "public_updated_at": "2011-02-04T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14352,6 +14624,7 @@
       ]
     },
     "government/publications/getting-them-reading-early": {
+      "document_type": "research",
       "public_updated_at": "2014-10-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14379,6 +14652,7 @@
       ]
     },
     "government/publications/good-practice-in-primary-mathematics-evidence-from-successful-schools": {
+      "document_type": "research",
       "public_updated_at": "2011-11-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14406,6 +14680,7 @@
       ]
     },
     "government/publications/group-performance-in-the-key-stage-2-science-tests-2010-and-2011": {
+      "document_type": "research",
       "public_updated_at": "2014-02-11T09:30:00.000+00:00",
       "organisations": [
         {
@@ -14433,6 +14708,7 @@
       ]
     },
     "government/publications/helping-children-become-independent-learners-and-confident-writers": {
+      "document_type": "research",
       "public_updated_at": "2012-03-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14460,6 +14736,7 @@
       ]
     },
     "government/publications/helping-primary-pupils-to-be-enthusiastic-and-able-linguists": {
+      "document_type": "research",
       "public_updated_at": "2012-03-14T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14487,6 +14764,7 @@
       ]
     },
     "government/publications/helping-pupils-excel-at-and-enjoy-mathematics": {
+      "document_type": "research",
       "public_updated_at": "2014-02-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14514,6 +14792,7 @@
       ]
     },
     "government/publications/how-do-pupils-progress-during-key-stages-2-and-3": {
+      "document_type": "research",
       "public_updated_at": "2011-03-31T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14541,6 +14820,7 @@
       ]
     },
     "government/publications/i-cans-early-talk-programme-independent-evaluation-of-the-impact-of-early-talk-on-addressing-speech-communication-and-language-needs-in-sure-start": {
+      "document_type": "research",
       "public_updated_at": "2011-01-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14568,6 +14848,7 @@
       ]
     },
     "government/publications/impact-assessment-opinion-early-years-foundation-stage-learning-and-development-requirements-amendment-order-2012": {
+      "document_type": "research",
       "public_updated_at": "2014-12-30T09:30:55.000+00:00",
       "organisations": [
         {
@@ -14595,6 +14876,7 @@
       ]
     },
     "government/publications/improving-boys-literacy-skills": {
+      "document_type": "research",
       "public_updated_at": "2015-07-13T09:15:02.000+00:00",
       "organisations": [
         {
@@ -14622,6 +14904,7 @@
       ]
     },
     "government/publications/improving-girls-attainment-in-mathematics": {
+      "document_type": "research",
       "public_updated_at": "2012-09-11T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14649,6 +14932,7 @@
       ]
     },
     "government/publications/improving-science-with-the-lab-13-project": {
+      "document_type": "research",
       "public_updated_at": "2015-03-03T10:27:54.000+00:00",
       "organisations": [
         {
@@ -14676,6 +14960,7 @@
       ]
     },
     "government/publications/improving-teaching-and-learning-using-the-outdoor-environment-at-preesall-fleetwoods-charity-church-of-england-primary": {
+      "document_type": "research",
       "public_updated_at": "2011-03-28T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14703,6 +14988,7 @@
       ]
     },
     "government/publications/independent-review-of-key-stage-2-testing-assessment-and-accountability-final-report": {
+      "document_type": "independent_report",
       "public_updated_at": "2011-06-23T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14730,6 +15016,7 @@
       ]
     },
     "government/publications/information-and-communication-technology-is-not-just-computers": {
+      "document_type": "research",
       "public_updated_at": "2012-03-23T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14757,6 +15044,7 @@
       ]
     },
     "government/publications/information-for-parents-2016-national-curriculum-test-results-at-the-end-of-key-stage-1": {
+      "document_type": "promotional",
       "public_updated_at": "2016-06-03T15:58:16.000+00:00",
       "organisations": [
         {
@@ -14784,6 +15072,7 @@
       ]
     },
     "government/publications/innovative-curriculum-design-to-raise-attainment": {
+      "document_type": "research",
       "public_updated_at": "2012-11-12T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14811,6 +15100,7 @@
       ]
     },
     "government/publications/inspiring-childrens-creativity-with-art": {
+      "document_type": "research",
       "public_updated_at": "2012-03-14T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14838,6 +15128,7 @@
       ]
     },
     "government/publications/integrated-review-at-age-2-implementation-study": {
+      "document_type": "research",
       "public_updated_at": "2014-11-21T09:30:04.000+00:00",
       "organisations": [
         {
@@ -14865,6 +15156,7 @@
       ]
     },
     "government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-1": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-09-17T12:47:00.000+00:00",
       "organisations": [
         {
@@ -14892,6 +15184,7 @@
       ]
     },
     "government/publications/interim-frameworks-for-teacher-assessment-at-the-end-of-key-stage-2": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-11-04T10:36:30.000+00:00",
       "organisations": [
         {
@@ -14919,6 +15212,7 @@
       ]
     },
     "government/publications/investigating-reliability-in-key-stage-2-tests": {
+      "document_type": "research",
       "public_updated_at": "2013-05-15T23:00:00.000+00:00",
       "organisations": [
         {
@@ -14946,6 +15240,7 @@
       ]
     },
     "government/publications/investigating-the-role-of-language-in-childrens-early-educational-outcomes": {
+      "document_type": "research",
       "public_updated_at": "2011-06-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -14973,6 +15268,7 @@
       ]
     },
     "government/publications/investigation-of-key-stage-2-level-6-tests": {
+      "document_type": "research",
       "public_updated_at": "2013-04-02T00:00:00.000+00:00",
       "organisations": [
         {
@@ -15000,6 +15296,7 @@
       ]
     },
     "government/publications/key-stage-1-and-2-maladministration-investigation-procedures": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-29T15:05:11.000+00:00",
       "organisations": [
         {
@@ -15027,6 +15324,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-collection-2012-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2011-12-06T00:00:00.000+00:00",
       "organisations": [
         {
@@ -15054,6 +15352,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-collection-2013-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2013-06-11T23:00:00.000+00:00",
       "organisations": [
         {
@@ -15081,6 +15380,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-collection-2013-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2013-04-11T23:00:00.000+00:00",
       "organisations": [
         {
@@ -15108,6 +15408,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-collection-2014-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2014-06-10T11:24:55.000+00:00",
       "organisations": [
         {
@@ -15135,6 +15436,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-collection-2015-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-08T10:51:46.000+00:00",
       "organisations": [
         {
@@ -15162,6 +15464,7 @@
       ]
     },
     "government/publications/key-stage-1-assessments-specification-for-the-2014-data-return": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-10T11:54:00.000+00:00",
       "organisations": [
         {
@@ -15189,6 +15492,7 @@
       ]
     },
     "government/publications/key-stage-1-english-grammar-punctuation-and-spelling-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T15:43:55.000+00:00",
       "organisations": [
         {
@@ -15216,6 +15520,7 @@
       ]
     },
     "government/publications/key-stage-1-english-reading-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-29T16:23:28.000+00:00",
       "organisations": [
         {
@@ -15243,6 +15548,7 @@
       ]
     },
     "government/publications/key-stage-1-mathematics-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-29T16:24:13.000+00:00",
       "organisations": [
         {
@@ -15270,6 +15576,7 @@
       ]
     },
     "government/publications/key-stage-1-phonics-screening-check-administration-guidance": {
+      "document_type": "guidance",
       "public_updated_at": "2016-06-27T12:17:38.000+00:00",
       "organisations": [
         {
@@ -15297,6 +15604,7 @@
       ]
     },
     "government/publications/key-stage-1-tasks-and-tests-materials-for-pupils-with-a-visual-impairment": {
+      "document_type": "guidance",
       "public_updated_at": "2014-09-05T09:54:00.000+00:00",
       "organisations": [
         {
@@ -15324,6 +15632,7 @@
       ]
     },
     "government/publications/key-stage-1-tests-2016-english-grammar-punctuation-and-spelling-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-06-03T11:36:54.000+00:00",
       "organisations": [
         {
@@ -15351,6 +15660,7 @@
       ]
     },
     "government/publications/key-stage-1-tests-2016-english-reading-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-06-03T11:36:29.000+00:00",
       "organisations": [
         {
@@ -15378,6 +15688,7 @@
       ]
     },
     "government/publications/key-stage-1-tests-2016-mathematics-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-06-03T11:35:57.000+00:00",
       "organisations": [
         {
@@ -15405,6 +15716,7 @@
       ]
     },
     "government/publications/key-stage-1-tests-modified-test-administration-guidance-mtag": {
+      "document_type": "guidance",
       "public_updated_at": "2016-05-04T13:17:36.000+00:00",
       "organisations": [
         {
@@ -15432,6 +15744,7 @@
       ]
     },
     "government/publications/key-stage-1-tests-test-administration-guidance-tag": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-29T14:39:51.000+00:00",
       "organisations": [
         {
@@ -15459,6 +15772,7 @@
       ]
     },
     "government/publications/key-stage-2-attainment-for-children-recorded-as-adopted-from-care": {
+      "document_type": "transparency",
       "public_updated_at": "2014-07-27T09:00:32.000+00:00",
       "organisations": [
         {
@@ -15486,6 +15800,7 @@
       ]
     },
     "government/publications/key-stage-2-attendance-register-and-test-script-dispatch": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-31T17:52:37.000+00:00",
       "organisations": [
         {
@@ -15513,6 +15828,7 @@
       ]
     },
     "government/publications/key-stage-2-career-related-learning-pathfinder-evaluation": {
+      "document_type": "research",
       "public_updated_at": "2011-05-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -15540,6 +15856,7 @@
       ]
     },
     "government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T15:44:40.000+00:00",
       "organisations": [
         {
@@ -15567,6 +15884,7 @@
       ]
     },
     "government/publications/key-stage-2-english-grammar-punctuation-and-spelling-test-information-for-parents": {
+      "document_type": "guidance",
       "public_updated_at": "2012-06-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -15594,6 +15912,7 @@
       ]
     },
     "government/publications/key-stage-2-english-reading-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-29T16:56:55.000+00:00",
       "organisations": [
         {
@@ -15621,6 +15940,7 @@
       ]
     },
     "government/publications/key-stage-2-mathematics-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-07-09T16:11:39.000+00:00",
       "organisations": [
         {
@@ -15648,6 +15968,7 @@
       ]
     },
     "government/publications/key-stage-2-science-sampling-2014-methodological-note-and-outcomes": {
+      "document_type": "research",
       "public_updated_at": "2016-01-28T09:30:29.000+00:00",
       "organisations": [
         {
@@ -15675,6 +15996,7 @@
       ]
     },
     "government/publications/key-stage-2-science-sampling-test-framework": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-29T17:00:53.000+00:00",
       "organisations": [
         {
@@ -15702,6 +16024,7 @@
       ]
     },
     "government/publications/key-stage-2-science-sampling-tests": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-25T14:12:49.000+00:00",
       "organisations": [
         {
@@ -15729,6 +16052,7 @@
       ]
     },
     "government/publications/key-stage-2-teacher-assessment-data-collection-2014-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2013-12-03T11:08:00.000+00:00",
       "organisations": [
         {
@@ -15778,6 +16102,7 @@
       ]
     },
     "government/publications/key-stage-2-teacher-assessment-data-collection-2016-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T16:25:51.000+00:00",
       "organisations": [
         {
@@ -15805,6 +16130,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-2016-english-grammar-punctuation-and-spelling-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-05-23T13:00:36.000+00:00",
       "organisations": [
         {
@@ -15832,6 +16158,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-2016-english-reading-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-05-23T13:00:16.000+00:00",
       "organisations": [
         {
@@ -15859,6 +16186,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-2016-mathematics-test-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2016-05-23T13:00:50.000+00:00",
       "organisations": [
         {
@@ -15886,6 +16214,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-an-overview": {
+      "document_type": "guidance",
       "public_updated_at": "2013-09-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -15913,6 +16242,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-and-phonics-screening-check-keep-materials-secure": {
+      "document_type": "guidance",
       "public_updated_at": "2015-03-19T16:55:44.000+00:00",
       "organisations": [
         {
@@ -15940,6 +16270,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-demonstrate-correct-test-administration": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-31T17:52:58.000+00:00",
       "organisations": [
         {
@@ -15967,6 +16298,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-modified-test-administration-guidance-mtag": {
+      "document_type": "guidance",
       "public_updated_at": "2016-04-11T13:35:00.000+00:00",
       "organisations": [
         {
@@ -15994,6 +16326,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-notes-for-teachers-on-how-the-english-grammar-punctuation-and-spelling-test-is-marked": {
+      "document_type": "guidance",
       "public_updated_at": "2013-11-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16021,6 +16354,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-notes-for-teachers-on-how-to-prepare-for-onscreen-marking": {
+      "document_type": "guidance",
       "public_updated_at": "2016-05-04T13:14:29.000+00:00",
       "organisations": [
         {
@@ -16048,6 +16382,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-service-childrens-education-schools": {
+      "document_type": "guidance",
       "public_updated_at": "2015-03-19T17:05:00.000+00:00",
       "organisations": [
         {
@@ -16075,6 +16410,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-test-administration-guidance-tag": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-31T17:52:00.000+00:00",
       "organisations": [
         {
@@ -16102,6 +16438,7 @@
       ]
     },
     "government/publications/key-stage-2-tests-when-pupils-should-take-the-tests": {
+      "document_type": "guidance",
       "public_updated_at": "2014-09-05T13:32:00.000+00:00",
       "organisations": [
         {
@@ -16129,6 +16466,7 @@
       ]
     },
     "government/publications/key-stage-2-writing-moderation-evaluation-of-the-20112012-interim-arrangements": {
+      "document_type": "research",
       "public_updated_at": "2012-12-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16156,6 +16494,7 @@
       ]
     },
     "government/publications/ks1-assessments-data-collection-2015-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2015-04-17T15:58:21.000+00:00",
       "organisations": [
         {
@@ -16183,6 +16522,7 @@
       ]
     },
     "government/publications/languages-at-the-heart-of-the-curriculum": {
+      "document_type": "research",
       "public_updated_at": "2013-10-24T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16210,6 +16550,7 @@
       ]
     },
     "government/publications/learning-english-as-an-additional-language-in-primary-school": {
+      "document_type": "research",
       "public_updated_at": "2012-09-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16237,6 +16578,7 @@
       ]
     },
     "government/publications/learning-to-read-through-phonics-information-for-parents": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-03T15:56:59.000+00:00",
       "organisations": [
         {
@@ -16264,6 +16606,7 @@
       ]
     },
     "government/publications/learning-together-through-play-in-the-early-years": {
+      "document_type": "research",
       "public_updated_at": "2015-07-13T09:15:00.000+00:00",
       "organisations": [
         {
@@ -16291,6 +16634,7 @@
       ]
     },
     "government/publications/letters-and-sounds-principles-and-practice-of-high-quality-phonics-phase-one-teaching-programme": {
+      "document_type": "guidance",
       "public_updated_at": "2008-09-18T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16318,6 +16662,7 @@
       ]
     },
     "government/publications/letters-and-sounds": {
+      "document_type": "guidance",
       "public_updated_at": "2007-04-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16345,6 +16690,7 @@
       ]
     },
     "government/publications/loosen-up-to-become-outstanding-in-mathematics": {
+      "document_type": "research",
       "public_updated_at": "2013-01-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16372,6 +16718,7 @@
       ]
     },
     "government/publications/making-connections-a-holistic-approach-to-pupil-assessment": {
+      "document_type": "research",
       "public_updated_at": "2012-07-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16399,6 +16746,7 @@
       ]
     },
     "government/publications/making-the-most-of-the-local-environment-to-develop-pre-school-learning": {
+      "document_type": "research",
       "public_updated_at": "2012-06-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16426,6 +16774,7 @@
       ]
     },
     "government/publications/maths-programmes-of-study-for-key-stage-1-and-2-until-july-2015": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "1999-09-01T08:00:00.000+00:00",
       "organisations": [
         {
@@ -16453,6 +16802,7 @@
       ]
     },
     "government/publications/meeting-technological-challenges-school-design-and-technology-provision": {
+      "document_type": "research",
       "public_updated_at": "2011-03-25T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16480,6 +16830,7 @@
       ]
     },
     "government/publications/modern-languages-achievement-and-challenge-2007-to-2010": {
+      "document_type": "research",
       "public_updated_at": "2011-01-11T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16507,6 +16858,7 @@
       ]
     },
     "government/publications/moving-on-up-transitioning-chidren-to-year-1": {
+      "document_type": "research",
       "public_updated_at": "2012-09-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16534,6 +16886,7 @@
       ]
     },
     "government/publications/music-in-schools-sound-partnerships-eight-effective-music-education-partnerships": {
+      "document_type": "research",
       "public_updated_at": "2012-12-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -16561,6 +16914,7 @@
       ]
     },
     "government/publications/national-curriculum-and-assessment-information-for-schools": {
+      "document_type": "guidance",
       "public_updated_at": "2014-08-21T15:33:00.000+00:00",
       "organisations": [
         {
@@ -16588,6 +16942,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-art-and-design-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16615,6 +16970,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-computing-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16642,6 +16998,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-design-and-technology-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16669,6 +17026,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-english-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2014-07-16T09:51:11.000+00:00",
       "organisations": [
         {
@@ -16696,6 +17054,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-framework-for-key-stages-1-to-4": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2014-12-02T12:08:38.000+00:00",
       "organisations": [
         {
@@ -16723,6 +17082,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-geography-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16750,6 +17110,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-history-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16777,6 +17138,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-languages-progammes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16804,6 +17166,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-mathematics-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2014-07-16T09:51:40.000+00:00",
       "organisations": [
         {
@@ -16831,6 +17194,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-music-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16858,6 +17222,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-physical-education-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2013-09-11T15:00:00.000+00:00",
       "organisations": [
         {
@@ -16885,6 +17250,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-primary-curriculum": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-05-06T15:00:54.000+00:00",
       "organisations": [
         {
@@ -16912,6 +17278,7 @@
       ]
     },
     "government/publications/national-curriculum-in-england-science-programmes-of-study": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-05-06T14:52:05.000+00:00",
       "organisations": [
         {
@@ -16939,6 +17306,7 @@
       ]
     },
     "government/publications/national-curriculum-tests-international-schools": {
+      "document_type": "guidance",
       "public_updated_at": "2015-03-19T16:07:22.000+00:00",
       "organisations": [
         {
@@ -16966,6 +17334,7 @@
       ]
     },
     "government/publications/national-curriculum-video-interviews-for-schools": {
+      "document_type": "promotional",
       "public_updated_at": "2014-05-29T13:16:30.000+00:00",
       "organisations": [
         {
@@ -16993,6 +17362,7 @@
       ]
     },
     "government/publications/new-arrivals-learning-english-as-an-additional-language": {
+      "document_type": "research",
       "public_updated_at": "2011-05-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17020,6 +17390,7 @@
       ]
     },
     "government/publications/notes-for-readers-in-the-english-grammar-punctuation-and-spelling-test-short-answer-questions": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-31T17:51:36.000+00:00",
       "organisations": [
         {
@@ -17047,6 +17418,7 @@
       ]
     },
     "government/publications/off-to-a-flying-start-assessment-in-reception-year": {
+      "document_type": "research",
       "public_updated_at": "2012-07-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17074,6 +17446,7 @@
       ]
     },
     "government/publications/partnerships-between-parents-and-carers": {
+      "document_type": "research",
       "public_updated_at": "2013-07-03T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17101,6 +17474,7 @@
       ]
     },
     "government/publications/phonics-screening-check-2012-technical-report": {
+      "document_type": "research",
       "public_updated_at": "2013-03-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17128,6 +17502,7 @@
       ]
     },
     "government/publications/phonics-screening-check-2013-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2013-06-27T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17155,6 +17530,7 @@
       ]
     },
     "government/publications/phonics-screening-check-2013-technical-report": {
+      "document_type": "guidance",
       "public_updated_at": "2014-05-01T08:31:51.000+00:00",
       "organisations": [
         {
@@ -17204,6 +17580,7 @@
       ]
     },
     "government/publications/phonics-screening-check-2014-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2014-06-30T10:31:00.000+00:00",
       "organisations": [
         {
@@ -17231,6 +17608,7 @@
       ]
     },
     "government/publications/phonics-screening-check-2015-materials": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-29T09:35:48.000+00:00",
       "organisations": [
         {
@@ -17258,6 +17636,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2012-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2013-12-17T16:08:46.000+00:00",
       "organisations": [
         {
@@ -17285,6 +17664,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2013-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2013-06-11T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17312,6 +17692,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2013-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2013-04-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17339,6 +17720,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2014-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2014-06-09T13:20:47.000+00:00",
       "organisations": [
         {
@@ -17366,6 +17748,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2014-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-08T14:10:00.000+00:00",
       "organisations": [
         {
@@ -17393,6 +17776,7 @@
       ]
     },
     "government/publications/phonics-screening-check-data-collection-2015-guide": {
+      "document_type": "guidance",
       "public_updated_at": "2015-06-08T10:51:00.000+00:00",
       "organisations": [
         {
@@ -17420,6 +17804,7 @@
       ]
     },
     "government/publications/phonics-screening-check-evaluation-final-report": {
+      "document_type": "research",
       "public_updated_at": "2015-06-25T09:01:11.000+00:00",
       "organisations": [
         {
@@ -17447,6 +17832,7 @@
       ]
     },
     "government/publications/phonics-screening-check-evaluation": {
+      "document_type": "research",
       "public_updated_at": "2014-05-01T08:31:01.000+00:00",
       "organisations": [
         {
@@ -17474,6 +17860,7 @@
       ]
     },
     "government/publications/phonics-screening-check-pilot-2011-technical-report": {
+      "document_type": "research",
       "public_updated_at": "2012-02-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17501,6 +17888,7 @@
       ]
     },
     "government/publications/phonics-screening-check-responding-to-the-results": {
+      "document_type": "guidance",
       "public_updated_at": "2013-02-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -17528,6 +17916,7 @@
       ]
     },
     "government/publications/phonics-screening-check-sample-materials-and-training-video": {
+      "document_type": "guidance",
       "public_updated_at": "2012-10-14T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17555,6 +17944,7 @@
       ]
     },
     "government/publications/phonics-screening-data-collection-2015-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2015-04-17T15:58:20.000+00:00",
       "organisations": [
         {
@@ -17582,6 +17972,7 @@
       ]
     },
     "government/publications/phonics-screening-data-collection-2016-technical-specification": {
+      "document_type": "guidance",
       "public_updated_at": "2016-02-01T13:14:19.000+00:00",
       "organisations": [
         {
@@ -17609,6 +18000,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-adaptaboard-advanced": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-16T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17636,6 +18028,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-autopress-education": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17663,6 +18056,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-bug-club": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17690,6 +18084,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-dandelion-books": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17717,6 +18112,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-floppys-phonics-sounds-and-letters": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17744,6 +18140,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-jolly-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17771,6 +18168,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-jolly-readers": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17798,6 +18196,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-letterland-my-alphabet-storybooks": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17825,6 +18224,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-letterland-phonics-readers-sets-1-to-4": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17852,6 +18252,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-letterland-phonics-revised-edition": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17879,6 +18280,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-letters-and-sounds": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17906,6 +18308,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-monster-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-22T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17933,6 +18336,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-phonics-bug": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17960,6 +18364,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-phonics-international": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -17987,6 +18392,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-project-x-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18014,6 +18420,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-read-write-inc-fresh-start": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18041,6 +18448,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-read-write-inc": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18068,6 +18476,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-reading-corner-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18095,6 +18504,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-songbirds-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18122,6 +18532,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-sound-discovery--2": {
+      "document_type": "form",
       "public_updated_at": "2013-03-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18149,6 +18560,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-sound-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18176,6 +18588,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-sounds-write": {
+      "document_type": "guidance",
       "public_updated_at": "2013-05-12T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18203,6 +18616,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-tap-tap-bat-system": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-22T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18230,6 +18644,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-teach-your-monster-to-read": {
+      "document_type": "guidance",
       "public_updated_at": "2014-06-18T12:55:12.000+00:00",
       "organisations": [
         {
@@ -18257,6 +18672,7 @@
       ]
     },
     "government/publications/phonics-self-assessment-form-tts-group": {
+      "document_type": "guidance",
       "public_updated_at": "2014-04-22T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18284,6 +18700,7 @@
       ]
     },
     "government/publications/phonics-teaching-materials-core-criteria-and-self-assessment": {
+      "document_type": "guidance",
       "public_updated_at": "2010-09-30T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18311,6 +18728,7 @@
       ]
     },
     "government/publications/phonics-year-1-screening-check-statistics": {
+      "document_type": "transparency",
       "public_updated_at": "2014-09-25T15:41:21.000+00:00",
       "organisations": [
         {
@@ -18338,6 +18756,7 @@
       ]
     },
     "government/publications/pirls-2011-reading-achievement-in-england-brief": {
+      "document_type": "research",
       "public_updated_at": "2012-11-12T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18365,6 +18784,7 @@
       ]
     },
     "government/publications/practitioners-experiences-of-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2010-08-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18392,6 +18812,7 @@
       ]
     },
     "government/publications/pre-key-stage-1-pupils-working-below-the-test-standard": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-12-11T09:43:00.000+00:00",
       "organisations": [
         {
@@ -18419,6 +18840,7 @@
       ]
     },
     "government/publications/pre-key-stage-2-pupils-working-below-the-test-standard": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "2015-12-11T09:47:00.000+00:00",
       "organisations": [
         {
@@ -18446,6 +18868,7 @@
       ]
     },
     "government/publications/pre-school-and-early-home-learning-effects-on-a-level-outcomes": {
+      "document_type": "research",
       "public_updated_at": "2015-12-07T10:00:29.000+00:00",
       "organisations": [
         {
@@ -18473,6 +18896,7 @@
       ]
     },
     "government/publications/promoting-learning-through-languages-in-nurseries": {
+      "document_type": "research",
       "public_updated_at": "2012-07-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18500,6 +18924,7 @@
       ]
     },
     "government/publications/raising-achievement-when-english-is-an-additional-language": {
+      "document_type": "research",
       "public_updated_at": "2012-02-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18527,6 +18952,7 @@
       ]
     },
     "government/publications/raising-learning-standards-by-learning-outside": {
+      "document_type": "research",
       "public_updated_at": "2012-03-12T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18554,6 +18980,7 @@
       ]
     },
     "government/publications/raising-standards-in-primary-mathematics": {
+      "document_type": "research",
       "public_updated_at": "2013-01-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18581,6 +19008,7 @@
       ]
     },
     "government/publications/reading-by-six-how-the-best-schools-do-it": {
+      "document_type": "research",
       "public_updated_at": "2010-11-14T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18608,6 +19036,7 @@
       ]
     },
     "government/publications/reading-supporting-higher-standards-in-schools": {
+      "document_type": "policy_paper",
       "public_updated_at": "2015-03-05T00:15:12.000+00:00",
       "organisations": [
         {
@@ -18635,6 +19064,7 @@
       ]
     },
     "government/publications/ready-to-read-how-a-sample-of-primary-schools-in-stoke-on-trent-teach-pupils-to-read": {
+      "document_type": "research",
       "public_updated_at": "2014-06-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18662,6 +19092,7 @@
       ]
     },
     "government/publications/reception-baseline-comparability-study": {
+      "document_type": "research",
       "public_updated_at": "2016-04-07T15:48:48.000+00:00",
       "organisations": [
         {
@@ -18689,6 +19120,7 @@
       ]
     },
     "government/publications/reception-baseline-research": {
+      "document_type": "research",
       "public_updated_at": "2015-07-16T09:05:00.000+00:00",
       "organisations": [
         {
@@ -18716,6 +19148,7 @@
       ]
     },
     "government/publications/removing-barriers-to-literacy": {
+      "document_type": "research",
       "public_updated_at": "2011-01-21T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18743,6 +19176,7 @@
       ]
     },
     "government/publications/request-about-the-national-curriculum-review": {
+      "document_type": "foi_release",
       "public_updated_at": "2011-07-22T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18770,6 +19204,7 @@
       ]
     },
     "government/publications/research-evidence-on-reading-for-pleasure": {
+      "document_type": "research",
       "public_updated_at": "2012-05-14T23:00:00.000+00:00",
       "organisations": [
         {
@@ -18797,6 +19232,7 @@
       ]
     },
     "government/publications/results-of-the-early-years-foundation-stage-profile-pilot": {
+      "document_type": "research",
       "public_updated_at": "2013-03-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18824,6 +19260,7 @@
       ]
     },
     "government/publications/review-of-key-stage-2-testing-assessment-and-accountability-progress-report": {
+      "document_type": "guidance",
       "public_updated_at": "2011-04-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18851,6 +19288,7 @@
       ]
     },
     "government/publications/rochford-review-interim-recommendations": {
+      "document_type": "independent_report",
       "public_updated_at": "2016-02-05T14:20:11.000+00:00",
       "organisations": [
         {
@@ -18878,6 +19316,7 @@
       ]
     },
     "government/publications/science-programmes-of-study-for-key-stage-1-and-2-until-july-2015": {
+      "document_type": "statutory_guidance",
       "public_updated_at": "1999-09-01T08:00:00.000+00:00",
       "organisations": [
         {
@@ -18905,6 +19344,7 @@
       ]
     },
     "government/publications/statement-on-national-curriculum-tests": {
+      "document_type": "correspondence",
       "public_updated_at": "2010-09-27T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18932,6 +19372,7 @@
       ]
     },
     "government/publications/supporting-childrens-all-round-development-in-nursery": {
+      "document_type": "research",
       "public_updated_at": "2012-02-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -18959,6 +19400,7 @@
       ]
     },
     "government/publications/supporting-childrens-learning-through-teaching-and-play": {
+      "document_type": "research",
       "public_updated_at": "2015-07-13T09:15:02.000+00:00",
       "organisations": [
         {
@@ -18986,6 +19428,7 @@
       ]
     },
     "government/publications/supporting-language-development-in-young-children": {
+      "document_type": "research",
       "public_updated_at": "2012-02-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19013,6 +19456,7 @@
       ]
     },
     "government/publications/supporting-the-development-of-bilingualism-in-young-children": {
+      "document_type": "research",
       "public_updated_at": "2012-03-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19040,6 +19484,7 @@
       ]
     },
     "government/publications/teacher-assessment-moderation-requirements-for-key-stage-1": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T17:15:01.000+00:00",
       "organisations": [
         {
@@ -19067,6 +19512,7 @@
       ]
     },
     "government/publications/teacher-assessment-moderation-requirements-for-key-stage-2": {
+      "document_type": "guidance",
       "public_updated_at": "2016-03-24T17:16:05.000+00:00",
       "organisations": [
         {
@@ -19094,6 +19540,7 @@
       ]
     },
     "government/publications/teaching-creative-writing-a-workshop-approach": {
+      "document_type": "research",
       "public_updated_at": "2011-03-04T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19121,6 +19568,7 @@
       ]
     },
     "government/publications/teaching-the-higher-levels-of-phonics": {
+      "document_type": "guidance",
       "public_updated_at": "2012-02-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19148,6 +19596,7 @@
       ]
     },
     "government/publications/the-early-education-pilot-for-two-year-old-children-age-five-follow-up": {
+      "document_type": "research",
       "public_updated_at": "2013-03-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19175,6 +19624,7 @@
       ]
     },
     "government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-early-years-providers": {
+      "document_type": "guidance",
       "public_updated_at": "2012-10-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19202,6 +19652,7 @@
       ]
     },
     "government/publications/the-early-years-foundation-stage-eyfs-learning-and-development-requirements-guidance-on-exemptions-for-individual-children": {
+      "document_type": "guidance",
       "public_updated_at": "2012-08-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19229,6 +19680,7 @@
       ]
     },
     "government/publications/the-early-years-foundations-for-life-health-and-learning-an-independent-report-on-the-early-years-foundation-stage-to-her-majestys-government": {
+      "document_type": "independent_report",
       "public_updated_at": "2011-03-30T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19256,6 +19708,7 @@
       ]
     },
     "government/publications/the-impact-of-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2011-02-10T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19283,6 +19736,7 @@
       ]
     },
     "government/publications/the-importance-of-music-a-national-plan-for-music-education": {
+      "document_type": "policy_paper",
       "public_updated_at": "2011-11-25T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19310,6 +19764,7 @@
       ]
     },
     "government/publications/the-route-to-a-good-and-improving-school": {
+      "document_type": "research",
       "public_updated_at": "2012-09-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19337,6 +19792,7 @@
       ]
     },
     "government/publications/the-sutherland-inquiry-an-independent-inquiry-into-the-delivery-of-national-curriculum-tests-in-2008": {
+      "document_type": "independent_report",
       "public_updated_at": "2008-12-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19364,6 +19820,7 @@
       ]
     },
     "government/publications/using-a-temporary-environment-to-enable-pre-school-learning": {
+      "document_type": "research",
       "public_updated_at": "2012-03-28T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19391,6 +19848,7 @@
       ]
     },
     "government/publications/using-art-craft-and-design-to-improve-self-confidence-and-creativity-in-primary-school": {
+      "document_type": "research",
       "public_updated_at": "2011-09-08T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19418,6 +19876,7 @@
       ]
     },
     "government/publications/using-child-initiated-learning-in-the-early-years-foundation-stage": {
+      "document_type": "research",
       "public_updated_at": "2012-03-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19445,6 +19904,7 @@
       ]
     },
     "government/publications/using-effective-lifelong-learning-inventory-to-help-young-children-learn": {
+      "document_type": "research",
       "public_updated_at": "2011-09-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19472,6 +19932,7 @@
       ]
     },
     "government/publications/using-modern-technology-to-improve-english": {
+      "document_type": "research",
       "public_updated_at": "2013-01-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19499,6 +19960,7 @@
       ]
     },
     "government/publications/using-the-outdoors-to-support-learning-and-play-in-primary-school": {
+      "document_type": "research",
       "public_updated_at": "2012-06-19T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19526,6 +19988,7 @@
       ]
     },
     "government/publications/using-the-physical-environment-as-a-tool-for-teaching": {
+      "document_type": "research",
       "public_updated_at": "2015-07-13T09:15:02.000+00:00",
       "organisations": [
         {
@@ -19553,6 +20016,7 @@
       ]
     },
     "government/publications/we-are-all-learners-here-our-lady-star-of-the-sea-nursery": {
+      "document_type": "research",
       "public_updated_at": "2014-07-03T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19580,6 +20044,7 @@
       ]
     },
     "government/publications/what-is-the-research-evidence-on-writing": {
+      "document_type": "research",
       "public_updated_at": "2012-11-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19607,6 +20072,7 @@
       ]
     },
     "government/publications/working-with-parents-and-carers-to-enhance-childrens-learning": {
+      "document_type": "research",
       "public_updated_at": "2013-03-07T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19634,6 +20100,7 @@
       ]
     },
     "government/publications/year-1-phonics-screening-check-pilot-evaluation": {
+      "document_type": "research",
       "public_updated_at": "2011-09-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19661,6 +20128,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-attainment-by-pupil-characteristics-academic-year-2010-to-2011": {
+      "document_type": "national_statistics",
       "public_updated_at": "2011-12-01T00:01:00.000+00:00",
       "organisations": [
         {
@@ -19688,6 +20156,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-2012-to-2013": {
+      "document_type": "national_statistics",
       "public_updated_at": "2013-10-24T08:30:00.000+00:00",
       "organisations": [
         {
@@ -19715,6 +20184,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-2013-to-2014": {
+      "document_type": "national_statistics",
       "public_updated_at": "2014-10-16T08:30:14.000+00:00",
       "organisations": [
         {
@@ -19742,6 +20212,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-2014-to-2015": {
+      "document_type": "national_statistics",
       "public_updated_at": "2015-11-19T09:30:34.000+00:00",
       "organisations": [
         {
@@ -19769,6 +20240,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2009-to-2010": {
+      "document_type": "national_statistics",
       "public_updated_at": "2010-10-12T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19796,6 +20268,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2010-to-2011": {
+      "document_type": "national_statistics",
       "public_updated_at": "2011-11-11T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19823,6 +20296,7 @@
       ]
     },
     "government/statistics/early-years-foundation-stage-profile-results-in-england-academic-year-2011-to-2012": {
+      "document_type": "national_statistics",
       "public_updated_at": "2012-10-17T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19850,6 +20324,7 @@
       ]
     },
     "government/statistics/eyfsp-attainment-by-pupil-characteristics-2013-to-2014": {
+      "document_type": "national_statistics",
       "public_updated_at": "2014-11-20T09:30:00.000+00:00",
       "organisations": [
         {
@@ -19877,6 +20352,7 @@
       ]
     },
     "government/statistics/eyfsp-attainment-by-pupil-characteristics-2013": {
+      "document_type": "national_statistics",
       "public_updated_at": "2013-11-21T09:53:00.000+00:00",
       "organisations": [
         {
@@ -19904,6 +20380,7 @@
       ]
     },
     "government/statistics/eyfsp-attainment-by-pupil-characteristics-in-england-academic-year-2011-to-2012": {
+      "document_type": "national_statistics",
       "public_updated_at": "2012-11-21T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19931,6 +20408,7 @@
       ]
     },
     "government/statistics/foundation-stage-profile-attainment-by-pupil-characteristics-england-academic-year-2009-to-2010": {
+      "document_type": "national_statistics",
       "public_updated_at": "2010-12-16T00:00:00.000+00:00",
       "organisations": [
         {
@@ -19958,6 +20436,7 @@
       ]
     },
     "government/speeches/assessment-after-levels": {
+      "document_type": "speech",
       "public_updated_at": "2015-02-25T16:18:16.000+00:00",
       "organisations": [
         {
@@ -19985,6 +20464,7 @@
       ]
     },
     "government/speeches/charlie-taylor-talks-about-developing-the-birth-to-18-system": {
+      "document_type": "speech",
       "public_updated_at": "2014-04-30T13:25:00.000+00:00",
       "organisations": [
         {
@@ -20034,6 +20514,7 @@
       ]
     },
     "government/speeches/education-minister-elizabeth-truss-speaks-at-the-north-of-england-education-conference": {
+      "document_type": "speech",
       "public_updated_at": "2013-01-18T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20061,6 +20542,7 @@
       ]
     },
     "government/speeches/education-secretary-michael-goves-speech-to-ascl": {
+      "document_type": "speech",
       "public_updated_at": "2012-03-26T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20088,6 +20570,7 @@
       ]
     },
     "government/speeches/education-secretary-michael-goves-speech-to-brighton-college": {
+      "document_type": "speech",
       "public_updated_at": "2012-05-10T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20115,6 +20598,7 @@
       ]
     },
     "government/speeches/elizabeth-truss-calls-for-a-renaissance-in-maths": {
+      "document_type": "speech",
       "public_updated_at": "2012-11-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20142,6 +20626,7 @@
       ]
     },
     "government/speeches/elizabeth-truss-on-increasing-the-number-of-pupils-studying-mandarin": {
+      "document_type": "speech",
       "public_updated_at": "2014-06-06T13:53:13.000+00:00",
       "organisations": [
         {
@@ -20169,6 +20654,7 @@
       ]
     },
     "government/speeches/elizabeth-truss-speaks-about-curriculum-reform": {
+      "document_type": "speech",
       "public_updated_at": "2013-09-18T14:24:39.000+00:00",
       "organisations": [
         {
@@ -20196,6 +20682,7 @@
       ]
     },
     "government/speeches/elizabeth-truss-speaks-about-how-schools-can-support-parents": {
+      "document_type": "speech",
       "public_updated_at": "2014-06-17T14:46:00.000+00:00",
       "organisations": [
         {
@@ -20223,6 +20710,7 @@
       ]
     },
     "government/speeches/michael-gove-an-education-system-which-works-for-every-child": {
+      "document_type": "speech",
       "public_updated_at": "2014-04-01T11:35:18.000+00:00",
       "organisations": [
         {
@@ -20250,6 +20738,7 @@
       ]
     },
     "government/speeches/michael-gove-at-the-national-college-annual-conference": {
+      "document_type": "speech",
       "public_updated_at": "2012-06-14T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20277,6 +20766,7 @@
       ]
     },
     "government/speeches/michael-gove-on-fasnas-first-twenty-years": {
+      "document_type": "speech",
       "public_updated_at": "2012-07-05T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20304,6 +20794,7 @@
       ]
     },
     "government/speeches/michael-gove-on-the-moral-purpose-of-school-reform": {
+      "document_type": "speech",
       "public_updated_at": "2011-06-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20331,6 +20822,7 @@
       ]
     },
     "government/speeches/michael-gove-speaks-about-the-importance-of-teaching": {
+      "document_type": "speech",
       "public_updated_at": "2013-09-13T16:51:54.000+00:00",
       "organisations": [
         {
@@ -20358,6 +20850,7 @@
       ]
     },
     "government/speeches/michael-gove-speaks-to-the-royal-society-on-maths-and-science": {
+      "document_type": "speech",
       "public_updated_at": "2013-11-20T11:35:17.000+00:00",
       "organisations": [
         {
@@ -20385,6 +20878,7 @@
       ]
     },
     "government/speeches/michael-gove-speech-at-the-bett-show-2012": {
+      "document_type": "speech",
       "public_updated_at": "2012-01-13T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20412,6 +20906,7 @@
       ]
     },
     "government/speeches/michael-gove-to-the-durand-academy": {
+      "document_type": "speech",
       "public_updated_at": "2011-09-01T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20439,6 +20934,7 @@
       ]
     },
     "government/speeches/michael-gove-to-the-local-government-association": {
+      "document_type": "speech",
       "public_updated_at": "2010-11-25T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20466,6 +20962,7 @@
       ]
     },
     "government/speeches/michael-gove-to-the-national-conference-of-directors-of-childrens-and-adult-services": {
+      "document_type": "speech",
       "public_updated_at": "2011-02-09T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20493,6 +20990,7 @@
       ]
     },
     "government/speeches/michael-gove-to-westminster-academy": {
+      "document_type": "speech",
       "public_updated_at": "2010-11-25T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20520,6 +21018,7 @@
       ]
     },
     "government/speeches/nick-cleggs-speech-on-education-and-outstanding-leaders": {
+      "document_type": "speech",
       "public_updated_at": "2013-10-24T13:50:21.000+00:00",
       "organisations": [
         {
@@ -20569,6 +21068,7 @@
       ]
     },
     "government/speeches/nick-gibb-at-the-voice-conference": {
+      "document_type": "speech",
       "public_updated_at": "2012-05-28T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20596,6 +21096,7 @@
       ]
     },
     "government/speeches/nick-gibb-speaks-at-the-centre-for-social-justice": {
+      "document_type": "speech",
       "public_updated_at": "2011-09-15T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20623,6 +21124,7 @@
       ]
     },
     "government/speeches/nick-gibb-speaks-at-the-music-education-expo": {
+      "document_type": "speech",
       "public_updated_at": "2015-03-12T14:53:41.000+00:00",
       "organisations": [
         {
@@ -20650,6 +21152,7 @@
       ]
     },
     "government/speeches/nick-gibb-speech-on-governments-maths-reforms": {
+      "document_type": "speech",
       "public_updated_at": "2015-03-27T12:09:36.000+00:00",
       "organisations": [
         {
@@ -20677,6 +21180,7 @@
       ]
     },
     "government/speeches/nick-gibb-the-fruits-of-autonomy": {
+      "document_type": "speech",
       "public_updated_at": "2014-11-13T14:00:00.000+00:00",
       "organisations": [
         {
@@ -20704,6 +21208,7 @@
       ]
     },
     "government/speeches/nick-gibb-the-importance-of-phonics": {
+      "document_type": "speech",
       "public_updated_at": "2015-03-28T18:44:37.000+00:00",
       "organisations": [
         {
@@ -20731,6 +21236,7 @@
       ]
     },
     "government/speeches/nick-gibb-to-the-association-of-teachers-and-lecturers-2011-conference": {
+      "document_type": "speech",
       "public_updated_at": "2011-04-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20758,6 +21264,7 @@
       ]
     },
     "government/speeches/nick-gibbs-speech-to-reform-aqa-conference": {
+      "document_type": "speech",
       "public_updated_at": "2011-06-28T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20785,6 +21292,7 @@
       ]
     },
     "government/speeches/nicky-morgan-discusses-the-future-of-education-in-england": {
+      "document_type": "speech",
       "public_updated_at": "2015-06-18T08:11:00.000+00:00",
       "organisations": [
         {
@@ -20812,6 +21320,7 @@
       ]
     },
     "government/speeches/nicky-morgan-improving-child-literacy-in-england": {
+      "document_type": "speech",
       "public_updated_at": "2015-09-24T10:00:04.000+00:00",
       "organisations": [
         {
@@ -20839,6 +21348,7 @@
       ]
     },
     "government/speeches/oral-statement-on-key-stage-2-tests": {
+      "document_type": "oral_statement",
       "public_updated_at": "2016-05-10T11:59:00.000+00:00",
       "organisations": [
         {
@@ -20888,6 +21398,7 @@
       ]
     },
     "government/speeches/sarah-teather-on-reforming-early-years": {
+      "document_type": "written_statement",
       "public_updated_at": "2011-12-20T00:00:00.000+00:00",
       "organisations": [
         {
@@ -20915,6 +21426,7 @@
       ]
     },
     "government/speeches/the-civil-rights-struggle-of-our-time": {
+      "document_type": "speech",
       "public_updated_at": "2013-11-22T16:40:00.000+00:00",
       "organisations": [
         {
@@ -20942,6 +21454,7 @@
       ]
     },
     "government/speeches/the-importance-of-storytelling": {
+      "document_type": "speech",
       "public_updated_at": "2016-02-03T17:06:17.000+00:00",
       "organisations": [
         {
@@ -20969,6 +21482,7 @@
       ]
     },
     "government/speeches/the-importance-of-teaching": {
+      "document_type": "speech",
       "public_updated_at": "2014-09-08T10:33:00.000+00:00",
       "organisations": [
         {
@@ -20996,6 +21510,7 @@
       ]
     },
     "government/speeches/what-is-a-good-education-in-the-21st-century": {
+      "document_type": "speech",
       "public_updated_at": "2016-02-05T15:24:00.000+00:00",
       "organisations": [
         {
@@ -21023,6 +21538,7 @@
       ]
     },
     "government/speeches/written-ministerial-statement-by-sarah-teather-on-the-early-years-foundation-stage": {
+      "document_type": "written_statement",
       "public_updated_at": "2012-03-27T00:00:00.000+00:00",
       "organisations": [
         {

--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -2,15 +2,15 @@
   "use strict";
 
   class ContentItem {
-    constructor(title, basePath, format, publicTimestamp) {
+    constructor(title, basePath, documentType, publicTimestamp) {
       this.title = title;
       this.basePath = basePath;
-      this.format = format;
+      this.documentType = documentType;
       this.publicTimestamp = publicTimestamp;
     }
 
     getHeading() {
-      switch (this.format) {
+      switch (this.documentType) {
         case 'news_article':
         case 'speech':
           return {
@@ -18,7 +18,15 @@
             id: 'news-and-events'
           };
           break;
+        case 'statutory_guidance':
+          return {
+            display_name: 'Statutory guidance',
+            id: 'statutory-guidance'
+          };
+          break;
         case 'answer':
+        case 'guidance':
+        case 'promotional':
         case 'detailed_guidance':
         case 'manual':
           return {
@@ -28,15 +36,33 @@
           break;
         case 'corporate_information_page':
         case 'organisation':
+        case 'corporate_report':
           return {
             display_name: 'Corporate information',
             id: 'corporate-information'
           };
           break;
+        case 'foi_release':
+        case 'correspondence':
+        case 'policy_paper':
+          return {
+            display_name: 'Government policy and responses',
+            id: 'government-policy-and-responses'
+          };
+          break;
+        case 'national_statistics':
         case 'statistics_announcement':
+        case 'transparency':
           return {
             display_name: 'Data and statistics',
             id: 'data-and-statistics'
+          };
+          break;
+        case 'research':
+        case 'independent_report':
+          return {
+            display_name: 'Research and analysis',
+            id: 'research-and-analysis'
           };
           break;
         case 'consultation':

--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -95,6 +95,7 @@ var ContentItem = require("./content_item.js");
       var childTaxons = metadata.children_of_taxon[basePath];
 
       contentItems.forEach(function(contentItem) {
+        var documentType = metadata.document_metadata[contentItem.link.substring(1)].document_type;
         var publicTimestamp = contentItem.public_timestamp;
 
         // Manual sections are missing a public timestamp: make one up
@@ -103,7 +104,7 @@ var ContentItem = require("./content_item.js");
             publicTimestamp = '2016-01-01T00:00:00+00:00';
         }
 
-        var contentItemModel = new ContentItem(contentItem.title, contentItem.link, contentItem.format, new Date(publicTimestamp));
+        var contentItemModel = new ContentItem(contentItem.title, contentItem.link, documentType, new Date(publicTimestamp));
         taxon.addContent(contentItemModel);
       });
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -31,7 +31,6 @@ var Taxon = require('./models/taxon.js');
     var taxon = Taxon.fromMetadata(url, metadata);
     var breadcrumb = breadcrumbMaker.getBreadcrumbForTaxon([url]);
     console.log("Taxon page for: %s", taxonName);
-    taxon = taxon.filterByHeading("other-guidance");
     res.render('taxonomy', {taxon: taxon, breadcrumb: breadcrumb});
   });
 

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -39,7 +39,7 @@
 
           {% if taxon.atozChildren().length > 0 %}
           {% for child_taxon in taxon.atozChildren() %}
-          <nav role="navigation" aria-labelledby="parent-other" class="full-list">
+          <nav role="navigation" aria-labelledby="parent-other" class="child-taxon-list">
             <h2>{{ child_taxon.title }}</h2>
             {% if child_taxon.description %}
             <p>{{ child_taxon.description }}</p>
@@ -56,15 +56,40 @@
           {% endfor %}
           {% endif %}
 
-          <nav role="navigation" aria-labelledby="parent-other" class="full-list">
+          <nav class="full-list">
             <h2>{{ taxon.title }}</h2>
-            <ul>
-              {% for contentItem in taxon.atozContent() %}
-              <li>
-                <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
-              </li>
-              {% endfor %}
-            </ul>
+            <div>
+              <nav role="navigation" aria-labelledby="parent-other">
+                <h3>Statutory guidance</h3>
+                <ul>
+                  {% for contentItem in taxon.filterByHeading('statutory-guidance').atozContent() %}
+                  <li>
+                    <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </nav>
+              <nav role="navigation" aria-labelledby="parent-other">
+                <h3>Other guidance</h3>
+                <ul>
+                  {% for contentItem in taxon.filterByHeading('other-guidance').atozContent() %}
+                  <li>
+                    <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </nav>
+              <nav role="navigation" aria-labelledby="parent-other">
+                <h3>Research and analysis</h3>
+                <ul>
+                  {% for contentItem in taxon.filterByHeading('research-and-analysis').atozContent() %}
+                  <li>
+                    <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
+                  </li>
+                  {% endfor %}
+                </ul>
+              </nav>
+            </div>
           </nav>
 
 

--- a/lib/ruby/content_item.rb
+++ b/lib/ruby/content_item.rb
@@ -15,6 +15,7 @@ class ContentItem
 
   def metadata
     {
+      "document_type" => content_item["document_type"],
       "public_updated_at" => content_item["public_updated_at"],
       "organisations" => content_item.dig("links", "organisations")
     }


### PR DESCRIPTION
This commit splits the long list of links on a taxon page into sections based on the document type, as obtained from the content store.