### PR TITLE
Merge guidance and hide empty lists

### DIFF
--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -19,19 +19,14 @@
           };
           break;
         case 'statutory_guidance':
-          return {
-            display_name: 'Statutory guidance',
-            id: 'statutory-guidance'
-          };
-          break;
         case 'answer':
         case 'guidance':
         case 'promotional':
         case 'detailed_guidance':
         case 'manual':
           return {
-            display_name: 'Other guidance',
-            id: 'other-guidance'
+            display_name: 'Guidance',
+            id: 'guidance'
           };
           break;
         case 'corporate_information_page':

--- a/app/routes.js
+++ b/app/routes.js
@@ -30,8 +30,18 @@ var Taxon = require('./models/taxon.js');
     var url = "/alpha-taxonomy/" + taxonName;
     var taxon = Taxon.fromMetadata(url, metadata);
     var breadcrumb = breadcrumbMaker.getBreadcrumbForTaxon([url]);
+
+    var taxon_content = {};
+
+    taxon_content.guidance = taxon.filterByHeading('guidance');
+    taxon_content.research_and_analysis = taxon.filterByHeading('research-and-analysis');
+
     console.log("Taxon page for: %s", taxonName);
-    res.render('taxonomy', {taxon: taxon, breadcrumb: breadcrumb});
+    res.render('taxonomy', {
+      taxon: taxon,
+      breadcrumb: breadcrumb,
+      taxon_content: taxon_content
+    });
   });
 
   router.get('/static-service/', function (req, res) {

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -56,14 +56,15 @@
           {% endfor %}
           {% endif %}
 
+          {% if taxon_content.guidance.content.length + taxon_content.research_and_analysis.content.length > 0 %}
           <nav class="full-list">
             <h2>{{ taxon.title }}</h2>
             <div>
-              {% if taxon.filterByHeading('guidance').content.length > 0 %}
+              {% if taxon_content.guidance.content.length > 0 %}
               <nav role="navigation" aria-labelledby="parent-other">
                 <h3>Guidance</h3>
                 <ul>
-                  {% for contentItem in taxon.filterByHeading('guidance').atozContent() %}
+                  {% for contentItem in taxon_content.guidance.atozContent() %}
                   <li>
                     <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
                   </li>
@@ -71,11 +72,11 @@
                 </ul>
               </nav>
               {% endif %}
-              {% if taxon.filterByHeading('research-and-analysis').content.length > 0 %}
+              {% if taxon_content.research_and_analysis.content.length > 0 %}
               <nav role="navigation" aria-labelledby="parent-other">
                 <h3>Research and analysis</h3>
                 <ul>
-                  {% for contentItem in taxon.filterByHeading('research-and-analysis').atozContent() %}
+                  {% for contentItem in taxon_content.research_and_analysis.atozContent() %}
                   <li>
                     <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
                   </li>
@@ -85,6 +86,7 @@
               {% endif %}
             </div>
           </nav>
+          {% endif %}
 
 
           <nav class="publisher-list">

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -60,19 +60,9 @@
             <h2>{{ taxon.title }}</h2>
             <div>
               <nav role="navigation" aria-labelledby="parent-other">
-                <h3>Statutory guidance</h3>
+                <h3>Guidance</h3>
                 <ul>
-                  {% for contentItem in taxon.filterByHeading('statutory-guidance').atozContent() %}
-                  <li>
-                    <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
-                  </li>
-                  {% endfor %}
-                </ul>
-              </nav>
-              <nav role="navigation" aria-labelledby="parent-other">
-                <h3>Other guidance</h3>
-                <ul>
-                  {% for contentItem in taxon.filterByHeading('other-guidance').atozContent() %}
+                  {% for contentItem in taxon.filterByHeading('guidance').atozContent() %}
                   <li>
                     <a href="{{ contentItem.basePath }}">{{ contentItem.title }}</a>
                   </li>

--- a/app/views/taxonomy.html
+++ b/app/views/taxonomy.html
@@ -59,6 +59,7 @@
           <nav class="full-list">
             <h2>{{ taxon.title }}</h2>
             <div>
+              {% if taxon.filterByHeading('guidance').content.length > 0 %}
               <nav role="navigation" aria-labelledby="parent-other">
                 <h3>Guidance</h3>
                 <ul>
@@ -69,6 +70,8 @@
                   {% endfor %}
                 </ul>
               </nav>
+              {% endif %}
+              {% if taxon.filterByHeading('research-and-analysis').content.length > 0 %}
               <nav role="navigation" aria-labelledby="parent-other">
                 <h3>Research and analysis</h3>
                 <ul>
@@ -79,6 +82,7 @@
                   {% endfor %}
                 </ul>
               </nav>
+              {% endif %}
             </div>
           </nav>
 


### PR DESCRIPTION
Merge "statutory guidance" and "other guidance" into a single "guidance" section.

Hide sections with no content.

Hide topics lists when there is no content in the filtered sections.