### PR TITLE
Add PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: govuk-content-navigation
+  command: node start.js
+  memory: 256M
+  buildpack: nodejs_buildpack


### PR DESCRIPTION
The commit adds a manifest.yaml file so that the prototype can be deployed to the PaaS.

Trello: https://trello.com/c/QkXpYD44/114-deploy-prototype-to-the-paas