### PR TITLE
Add .cfignore file for PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
This commit adds a `.cfignore` file, which is symlinked to `.gitignore`. This file tells the PaaS which files not to upload during deployment. The format is the same as `.gitignore`.

Trello: https://trello.com/c/QkXpYD44/114-deploy-prototype-to-the-paas