### PR TITLE
Pre-process datestamps

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -6,10 +6,9 @@ var expressNunjucks = require('express-nunjucks');
 var Promise = require('bluebird');
 var glob = Promise.promisify(require('glob'));
 var readFile = Promise.promisify(fs.readFile);
-//var cheerio = require('cheerio');
-var moment = require('moment');
 var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 var Taxon = require('./models/taxon.js');
+//var timestampHack = require('./lib/js/hack_timestamp.js');
 
 (function() {
   "use strict";
@@ -68,15 +67,12 @@ var Taxon = require('./models/taxon.js');
     }).then(function(filePath) {
       readFile(filePath).then(function(data) {
         content = data.toString();
-        //var $ = cheerio.load(content);
         var whitehall = filePath.match(/whitehall/);
         var html_manual = filePath.match(/manual/);
         var html_publication = content.match(/html-publications-show/);
         var public_timestamp = metadata.document_metadata[url].public_updated_at;
         var breadcrumb;
         var taxons;
-
-        //$('h1').first().after('<p class="hack-datestamp">Last updated: ' + moment(public_timestamp).fromNow() + '</p>');
 
         if (!html_publication) {
           // Skip breadcrumbs and taxons for HTML publications since they have a unique format

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,7 @@ var expressNunjucks = require('express-nunjucks');
 var Promise = require('bluebird');
 var glob = Promise.promisify(require('glob'));
 var readFile = Promise.promisify(fs.readFile);
-var cheerio = require('cheerio');
+//var cheerio = require('cheerio');
 var moment = require('moment');
 var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 var Taxon = require('./models/taxon.js');
@@ -68,7 +68,7 @@ var Taxon = require('./models/taxon.js');
     }).then(function(filePath) {
       readFile(filePath).then(function(data) {
         content = data.toString();
-        var $ = cheerio.load(content);
+        //var $ = cheerio.load(content);
         var whitehall = filePath.match(/whitehall/);
         var html_manual = filePath.match(/manual/);
         var html_publication = content.match(/html-publications-show/);
@@ -76,7 +76,7 @@ var Taxon = require('./models/taxon.js');
         var breadcrumb;
         var taxons;
 
-        $('h1').first().after('<p class="hack-datestamp">Last updated: ' + moment(public_timestamp).fromNow() + '</p>');
+        //$('h1').first().after('<p class="hack-datestamp">Last updated: ' + moment(public_timestamp).fromNow() + '</p>');
 
         if (!html_publication) {
           // Skip breadcrumbs and taxons for HTML publications since they have a unique format
@@ -84,16 +84,7 @@ var Taxon = require('./models/taxon.js');
           taxons = getTaxons(url);
         }
 
-        var data = {
-          content: $.html(),
-          publicTimestamp: public_timestamp,
-          breadcrumb: breadcrumb,
-          taxons: taxons,
-          whitehall: whitehall,
-          html_manual: html_manual
-        };
-
-        res.render('content', data);
+        res.render('content', { content: content, breadcrumb: breadcrumb, taxons: taxons, whitehall: whitehall, homepage_url: '/'});
       },
       function (e) {
         res.status(404).render('404');

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -3,3 +3,4 @@
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/govuk/selection-buttons.js"></script>
 <script src="/public/javascripts/application.js"></script>
+<!--<script src="/public/javascripts/hack-timestamp.js"></script>-->

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "bluebird": "^3.4.3",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
-    "cheerio": "^0.22.0",
     "consolidate": "0.x",
     "express": "4.13.3",
     "express-nunjucks": "^0.9.3",


### PR DESCRIPTION
Add datestamp to html beforehand using python script.  Using beautiful soup which gives a decent output as it has pretty printing built in (in comparison to Nokogiri).  Removing cheerio which could cause problems being synchronous, and also means that actual content isn't being injected in at the last minute.