### PR TITLE
Code refactoring and documentation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -120,7 +120,7 @@
         "no-implicit-coercion": "error",
         "no-implicit-globals": "error",
         "no-implied-eval": "error",
-        "no-inline-comments": "error",
+        "no-inline-comments": "off",
         "no-invalid-this": "error",
         "no-iterator": "error",
         "no-label-var": "error",

--- a/app/routes.js
+++ b/app/routes.js
@@ -7,9 +7,6 @@ var readFile = Promise.promisify(fs.readFile);
 var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 var Taxon = require('./models/taxon.js');
 
-(function () {
-  "use strict";
-
   router.get('/', function (req, res) {
     res.render('index');
   });
@@ -125,5 +122,3 @@ var Taxon = require('./models/taxon.js');
   }
 
   module.exports = router;
-
-})();

--- a/bin/fetch_main_content.py
+++ b/bin/fetch_main_content.py
@@ -1,7 +1,7 @@
 """
 This will traverse the govuk mirror for the files listed as links in
  Alex's CSV to be used in the prototype.  It will parse the html to
- to extract the content within the main tags and save this to the
+ to extract the content within the main html tags and save this to the
  target directory, which should be the content prototype.
 
 Usage:


### PR DESCRIPTION
- Remove 'Use strict' - unecessary inside of modules in es6.
- Remove iife, don't need this for module exports.

Remove inline comment complaints from eslint.

Change comment in python script.

- Add 'html' as main is a very vague word and it isn't clear what main tags means.