### PR TITLE
Extract document type examples from metadata and display on index page

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -4,6 +4,8 @@ var fs = require('fs');
 var Promise = require('bluebird');
 var glob = Promise.promisify(require('glob'));
 var readFile = Promise.promisify(fs.readFile);
+var _ = require('lodash');
+
 var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 var Taxon = require('./models/taxon.js');
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -33,7 +33,7 @@ var Taxon = require('./models/taxon.js');
     var taxonName = req.params.taxons;
     var url = "/alpha-taxonomy/" + taxonName;
     getMetadata().
-    then(function (metadata){
+    then(function (metadata) {
       var taxon = Taxon.fromMetadata(url, metadata);
       var breadcrumbMaker = new BreadcrumbMaker(metadata);
       var breadcrumb = breadcrumbMaker.getBreadcrumbForTaxon([url]);
@@ -68,7 +68,7 @@ var Taxon = require('./models/taxon.js');
     globPage.
     then(function (file) {
       var filePath = file[0];
-      
+
       return filePath;
     }).
     then(function (filePath) {
@@ -104,7 +104,7 @@ var Taxon = require('./models/taxon.js');
               whitehall: whitehall,
               htmlManual: htmlManual
             });
-          }); 
+          });
         }
         else {
           res.render('content', {
@@ -121,7 +121,7 @@ var Taxon = require('./models/taxon.js');
 
   function getMetadata () {
     return readFile('app/data/metadata_and_taxons.json').
-    catch(function (err){
+    catch(function (err) {
         console.log('Failed to read metadata and taxons.');
     }).
     then(function (data) {
@@ -131,7 +131,7 @@ var Taxon = require('./models/taxon.js');
 
   function getTaxons (url) {
     return getMetadata().
-    then(function (metadata){
+    then(function (metadata) {
       return metadata.taxons_for_content[url].
       map(function (taxonBasePath) {
         return Taxon.fromMetadata(taxonBasePath, metadata);

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,7 +10,23 @@ var BreadcrumbMaker = require('../lib/js/breadcrumb_maker.js');
 var Taxon = require('./models/taxon.js');
 
   router.get('/', function (req, res) {
-    res.render('index');
+    var documentTypeExamples = {};
+    getMetadata()
+      .then(function (metadata) {
+        var documentMetadata = metadata["document_metadata"];
+
+        _.each(documentMetadata, function (metadata, basePath) {
+          if(documentTypeExamples[metadata["document_type"]] == undefined) {
+            documentTypeExamples[metadata["document_type"]] = basePath;
+          }
+        });
+        documentTypeExamples = _.map(documentTypeExamples, function (basePath, documentType) {
+          return {documentType: documentType, basePath: basePath };
+        });
+        documentTypeExamples = _.sortBy(documentTypeExamples, "documentType");
+
+        res.render('index', { documentTypeExamples: documentTypeExamples });
+      })
   });
 
   router.get('/alpha-taxonomy/:taxons', function (req, res) {

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -22,19 +22,9 @@
       <p>Examples of different content by format</p>
 
       <ul class="list list-bullet">
-        <li><a href="/government/collections/phonics">Collection</a></li>
-        <li><a href="/government/consultations/new-national-curriculum-primary-assessment-and-accountability">Consultation</a></li>
-        <li><a href="/government/organisations/department-for-education/about">Corporate Information Page</a></li>
-        <li><a href="/guidance/key-stage-1-assessments">Detailed guidance</a></li>
-        <li><a href="/government/publications/national-curriculum-in-england-computing-programmes-of-study/national-curriculum-in-england-computing-programmes-of-study">HTML publication</a></li>
-        <li><a href="/guidance/2016-key-stage-1-assessment-and-reporting-arrangements-ara">Manual</a></li>
-        <li><a href="/government/news/a-third-of-children-reach-expected-level-in-pilot-of-phonics-check">News article</a></li>
-        <li><a href="/government/organisations/qualifications-and-curriculum-authority">Organisation</a></li>
-        <li><a href="/government/publications/2016-national-curriculum-tests-for-key-stages-1-and-2-information-for-parents">Publication (promotional material)</a></li>
-        <li><a href="/government/publications/statement-on-national-curriculum-tests">Publication (correspondance)</a></li>
-        <li><a href="/government/statistics/eyfsp-attainment-by-pupil-characteristics-2013">Publication (official statistics)</a></li>
-        <li><a href="/government/speeches/assessment-after-levels">Speech</a></li>
-        <li><a href="/government/statistics/announcements/eyfsp-attainment-by-pupil-characteristics-england-2015">Statistics anouncement</a></li>
+        {% for example in documentTypeExamples %}
+        <li><a href="{{example.basePath}}">{{example.documentType}}</a></li>
+        {% endfor %}
       </ul>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-sass": "^1.1.0",
     "grunt-sync": "^0.5.1",
     "hogan.js": "3.0.2",
+    "lodash": "4.16.6",
     "minimist": "0.0.8",
     "moment": "^2.15.1",
     "nunjucks": "^2.4.2",


### PR DESCRIPTION

https://trello.com/c/t85TTDmy/115-add-examples-of-formats-to-the-prototype-index