### PR TITLE
Remove detailed guidance

### DIFF
--- a/bin/fetch_main_content.py
+++ b/bin/fetch_main_content.py
@@ -19,7 +19,6 @@ import requests
 def main():
     whitehall_formats = ['collection',
                          'consultation',
-                         'detailed_guidance',
                          'document_collection',
                          'news_article',
                          'organisation',


### PR DESCRIPTION
Remove detailed guidance from list of whitehalls formats as this has been migrated.