### PR TITLE
Only show guidance content in the navigation views

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -36,6 +36,9 @@ var DocumentType = require('./models/document_type.js');
         taxonContent.guidance = taxon.filterByHeading('guidance');
 
         var childTaxons = taxon.atozChildren();
+        for (var i = 0; i < childTaxons.length; i++) {
+          childTaxons[i].guidance = childTaxons[i].filterByHeading('guidance');
+        }
         var grandchild = _.find(childTaxons, function (childTaxon) {
           return childTaxon.children.length > 0;
         });

--- a/app/views/taxonomy/penultimate-taxon.html
+++ b/app/views/taxonomy/penultimate-taxon.html
@@ -47,7 +47,7 @@
           {% for childTaxon in taxon.atozChildren() %}
             <h2>{{childTaxon.title}}</h2>
             <ul>
-              {% for content in childTaxon.content.slice(0,5) %}
+              {% for content in childTaxon.guidance.atozContent(5) %}
                 <li>
                   <h3><a href="{{ content.basePath }}">{{ content.title }}</a></h3>
                   <p>{{ content.description }}</p>
@@ -55,7 +55,7 @@
               {% endfor %}
             </ul>
 
-            {% if childTaxon.content.length > 5 %}
+            {% if childTaxon.guidance.content.length > 5 %}
               <p>
                 <a href="{{childTaxon.basePath}}?viewAll">More about {{ childTaxon.title }}</a>
               </p>


### PR DESCRIPTION
- Filter childTaxon content by guidance and add to object
- Loop through guidance alphabetically and output content
