### PR TITLE
Extract a TaxonPresenter out of the taxon route

### DIFF
--- a/app/models/taxon_presenter.js
+++ b/app/models/taxon_presenter.js
@@ -1,0 +1,72 @@
+"use strict";
+
+var urlHelper = require('url');
+
+var Taxon = require('./taxon.js');
+var BreadcrumbMaker = require('../../lib/js/breadcrumb_maker.js');
+
+class TaxonPresenter {
+  constructor (taxonParam, taxonomyData) {
+    this.taxonomyData = taxonomyData;
+    this.basePath = "/alpha-taxonomy/" + taxonParam;
+
+    this.build();
+  }
+
+  build () {
+    this.buildTaxon();
+    this.buildBreadcrumb();
+    this.buildParent();
+    this.buildChildren();
+    this.buildContent();
+    this.checkIfPenultimate();
+  }
+
+  buildTaxon () {
+    this.taxon = Taxon.fromMetadata(this.basePath, this.taxonomyData);
+    this.title = this.taxon.title;
+    this.description = this.taxon.description;
+  }
+
+  buildBreadcrumb () {
+    var breadcrumbMaker = new BreadcrumbMaker(this.taxonomyData);
+    this.breadcrumb =  breadcrumbMaker.getBreadcrumbForTaxon([this.basePath]);
+  }
+
+  buildParent () {
+    this.parent = this.breadcrumb[this.breadcrumb.length - 1];
+  }
+
+  buildChildren () {
+    this.children = this.taxon.atozChildren().map(function (child) {
+      child.guidance = child.filterByHeading('guidance');
+
+      return child;
+    })
+  }
+
+  buildContent () {
+    this.content = {}
+    this.content.guidance = this.taxon.filterByHeading('guidance');
+  }
+
+  checkIfPenultimate () {
+    var hasChildren = (childTaxon) => childTaxon.children.length > 0;
+    this.isPenultimate = !(this.children.find(hasChildren));
+  }
+
+  determineBackToLink (pageUrl) {
+    var backTo = null;
+    // The 'back to' link behaviour differs depending on whether we are showing
+    // a leaf node taxon or a taxon higher up in the taxonomy.
+    if (this.children.length > 0) {
+      backTo = urlHelper.parse(pageUrl).pathname;
+    } else {
+      backTo = this.parent.basePath;
+    }
+
+    return backTo
+  }
+}
+
+module.exports = TaxonPresenter;

--- a/app/views/taxonomy/_taxon-heading.html
+++ b/app/views/taxonomy/_taxon-heading.html
@@ -1,10 +1,12 @@
 <div class="grid-row">
   <div class="page-header">
     <h1>
-      <span class="sub-heading"><a href="{{ parentTaxon.basePath }}">{{ parentTaxon.title }}</a></span>
-      {{ taxon.title }}
+      <span class="sub-heading">
+        <a href="{{ presentedTaxon.parent.basePath }}">{{ presentedTaxon.parent.title }}</a>
+      </span>
+      {{ presentedTaxon.title }}
     </h1>
 
-    <p>{{ taxon.description }}</p>
+    <p>{{ presentedTaxon.description }}</p>
   </div>
 </div>

--- a/app/views/taxonomy/_truncated-content-list.html
+++ b/app/views/taxonomy/_truncated-content-list.html
@@ -1,8 +1,8 @@
-{% if taxonContent.guidance.content.length > 0 %}
-  <h2>{{ taxon.title }} guidance</h2>
+{% if presentedTaxon.content.guidance.content.length > 0 %}
+  <h2>{{ presentedTaxon.title }} guidance</h2>
 
   <ul>
-    {% for document in taxonContent.guidance.atozContent(5) %}
+    {% for document in presentedTaxon.content.guidance.atozContent(5) %}
       <li>
         <h3><a href="{{ document.basePath }}">{{ document.title }}</a></h3>
         <p>{{ document.description }}</p>
@@ -10,7 +10,7 @@
     {% endfor %}
   </ul>
 
-  {% if taxonContent.guidance.content.length > 5 %}
+  {% if presentedTaxon.content.guidance.content.length > 5 %}
     <p>
       <a href="{{taxon.basePath}}?viewAll">More about {{ taxon.title }}</a>
     </p>

--- a/app/views/taxonomy/penultimate-taxon.html
+++ b/app/views/taxonomy/penultimate-taxon.html
@@ -19,7 +19,7 @@
 
           {% include 'taxonomy/_truncated-content-list.html' %}
 
-          {% for childTaxon in taxon.atozChildren() %}
+          {% for childTaxon in presentedTaxon.children %}
             <h2>{{childTaxon.title}}</h2>
             <ul>
               {% for content in childTaxon.guidance.atozContent(5) %}

--- a/app/views/taxonomy/taxon.html
+++ b/app/views/taxonomy/taxon.html
@@ -18,7 +18,7 @@
         <nav role="navigation" class="child-topics-list">
           <h2>In this section</h2>
           <ul>
-            {% for childTaxon in taxon.atozChildren() %}
+            {% for childTaxon in presentedTaxon.children %}
               <li>
                 <h3><a href="{{ childTaxon.basePath }}">{{ childTaxon.title }}</a></h3>
                 <p>{{ childTaxon.description }}</p>

--- a/app/views/taxonomy/view-all.html
+++ b/app/views/taxonomy/view-all.html
@@ -14,29 +14,28 @@
     <div class="grid-row">
       <div class="page-header">
         <h1>
-          <span class="sub-heading"><a href="{{ backTo }}">{{ parentTaxon.title }}</a></span>
-          {{ taxon.title }}
+          <span class="sub-heading"><a href="{{ backTo }}">{{ presentedTaxon.parent.title }}</a></span>
+          {{ presentedTaxon.title }}
         </h1>
 
-        <p>{{ taxon.description }}</p>
+        <p>{{ presentedTaxon.description }}</p>
       </div>
     </div>
 
   <div class="grid-row child-topic-contents">
     <div class="column-two-thirds">
       <div class="topic-content">
-        <h2>{{ taxon.title}} guidance</h2>
-        
+        <h2>{{ presentedTaxon.taxon.title}} guidance</h2>
+
         <ul>
-          {% for document in taxonContent.guidance.atozContent() %}
-              <li>
-                <h3><a href="{{ document.basePath }}">{{ document.title }}</a></h3>
-                <p>{{ document.description }}</p>
-              </li>
+          {% for document in presentedTaxon.content.guidance.atozContent() %}
+            <li>
+              <h3><a href="{{ document.basePath }}">{{ document.title }}</a></h3>
+              <p>{{ document.description }}</p>
+            </li>
           {% endfor %}
         </ul>
     </div>
-
   </div>
 </main>
 


### PR DESCRIPTION
Makes the route implementation simpler. It focuses on request-handling
logic while the presenter assembles an object containing everything
needed to render the views.