### PR TITLE
Ignore .venv folder in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ node_modules/*
 .tmuxp.*
 link-checker-crawled-pages.pstore
 npm-debug.log
-venv
+.venv
 /*.txt


### PR DESCRIPTION
After installing the requirements, this folder is created locally. This commit makes sure we ignore it.