### PR TITLE
Add all document types that make up guidance

### DIFF
--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -9,65 +9,30 @@ class ContentItem {
     this.description = description;
   }
 
-  getHeading() {
+  getHeading () {
     switch (this.documentType) {
-      case 'news_article':
-      case 'speech':
-        return {
-          display_name: 'News and events',
-          id: 'news-and-events'
-        };
-        break;
       case 'statutory_guidance':
       case 'answer':
       case 'guidance':
-      case 'promotional':
       case 'detailed_guidance':
       case 'detailed_guide':
+      case 'form':
+      case 'guide':
+      case 'licence':
+      case 'local_transaction':
+      case 'map':
+      case 'notice':
+      case 'programme':
+      case 'promotional':
+      case 'regulation':
+      case 'simple_smart_answer':
+      case 'smartanswer':
       case 'manual':
       case 'manual_section':
         return {
           display_name: 'Guidance',
           id: 'guidance'
         };
-        break;
-      case 'corporate_information_page':
-      case 'organisation':
-      case 'corporate_report':
-        return {
-          display_name: 'Corporate information',
-          id: 'corporate-information'
-        };
-        break;
-      case 'foi_release':
-      case 'correspondence':
-      case 'policy_paper':
-        return {
-          display_name: 'Government policy and responses',
-          id: 'government-policy-and-responses'
-        };
-        break;
-      case 'national_statistics':
-      case 'statistics_announcement':
-      case 'transparency':
-        return {
-          display_name: 'Data and statistics',
-          id: 'data-and-statistics'
-        };
-        break;
-      case 'research':
-      case 'independent_report':
-        return {
-          display_name: 'Research and analysis',
-          id: 'research-and-analysis'
-        };
-        break;
-      case 'consultation':
-        return {
-          display_name: 'Consultations and notices',
-          id: 'consultations-and-notices'
-        };
-        break;
       default:
         return null;
     }


### PR DESCRIPTION
We have defined what guidance content should be. This commit removes
everything that is not guidance and adds the extra document types that
were missing.

Trello: https://trello.com/c/VV5tKrC5/263-make-sure-the-prototype-is-showing-the-correct-formats-for-guidance