### PR TITLE
Fix sorting of child taxons in grids

### DIFF
--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -73,7 +73,11 @@ class Taxon {
 
   atozChildren () {
     return this.children.sort(function (a, b) {
-      return a.title > b.title;
+      if (a.title >= b.title) {
+        return 1;
+      }
+
+      return -1;
     });
   }
 


### PR DESCRIPTION
`Array.prototype.sort()` expects a `comparableFunction` that returns 0,
less than 0 or more than 0 depending on the sort order we choose.

This commit changes the implementation of `atozChildren` in order to
sort child taxons alphabetically by titles in ascending order.

More details here:
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

Trello: https://trello.com/c/SObFWf2w/266-show-taxons-in-grid-sorted-alphabetically

Before:

<img width="1015" alt="screen shot 2016-11-29 at 16 55 51" src="https://cloud.githubusercontent.com/assets/416701/20719750/c75341e2-b654-11e6-919b-502a569d58c7.png">

After:

<img width="1035" alt="screen shot 2016-11-29 at 16 55 24" src="https://cloud.githubusercontent.com/assets/416701/20719756/cb5bb2ba-b654-11e6-9ecb-c1e351286b1a.png">