### PR TITLE
Remove links to content that doesn't exist

### DIFF
--- a/app/views/taxonomy/penultimate-taxon.html
+++ b/app/views/taxonomy/penultimate-taxon.html
@@ -13,14 +13,18 @@
 
     {% include 'taxonomy/_taxon-heading.html' %}
 
+    {% if presentedTaxon.children.length > 0 %}
     <h3>In this section</h3>
 
     <ul class="topic-navigation">
       <li><a href="#topic-01">{{ presentedTaxon.title }}</a></li>
       {% for childTaxon in presentedTaxon.children %}
+        {% if childTaxon.guidance.atozContent().length > 0 %}
         <li class="child-topic"><a href="#topic-{{ (loop.index + 1) | pad(2, '0') }}">{{ childTaxon.title }}</a></li>
+        {% endif %}
       {% endfor %}
     </ul>
+    {% endif %}
 
     <div class="grid-row child-topic-contents">
       <div class="column-two-thirds">


### PR DESCRIPTION
Only show section text and link if there is more than one topic in the section.  Only show topic links if they exist.

No Subtopics

Before: 
<img width="700" alt="screen shot 2016-12-06 at 15 33 19" src="https://cloud.githubusercontent.com/assets/11633362/20931574/7be86ef6-bbc9-11e6-95f1-3ed4b6b9389a.png">

After:
<img width="692" alt="screen shot 2016-12-06 at 15 32 24" src="https://cloud.githubusercontent.com/assets/11633362/20931593/8b72d9f6-bbc9-11e6-9e5b-0aaa48ddb826.png">

Empty Subtopics

Before:
<img width="668" alt="screen shot 2016-12-06 at 15 33 06" src="https://cloud.githubusercontent.com/assets/11633362/20931632/a522c15e-bbc9-11e6-96d1-d9d2e99eface.png">

After:
<img width="691" alt="screen shot 2016-12-06 at 15 32 40" src="https://cloud.githubusercontent.com/assets/11633362/20931649/ac2b66ea-bbc9-11e6-8ce3-b884ab37dddd.png">