### PR TITLE
Add missing formats

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -206,7 +206,10 @@
       text-decoration: underline;
    }
    li.current {
-     color: $secondary-text-colour;
+     a {
+       color: $secondary-text-colour;
+       text-decoration: none;
+     }
    }
 }
 #whitehall-wrapper {
@@ -214,6 +217,13 @@
       a {
          color: black;
          text-decoration: underline;
+      }
+
+      .current {
+        a {
+          color: $secondary-text-colour;
+          text-decoration: none;
+        }
       }
    }
 }

--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -11,24 +11,28 @@ class ContentItem {
 
   getHeading () {
     switch (this.documentType) {
-      case 'statutory_guidance':
       case 'answer':
-      case 'guidance':
+      case 'contact':
       case 'detailed_guidance':
       case 'detailed_guide':
       case 'form':
+      case 'guidance':
       case 'guide':
       case 'licence':
       case 'local_transaction':
+      case 'manual':
+      case 'manual_section':
       case 'map':
       case 'notice':
+      case 'place':
       case 'programme':
       case 'promotional':
       case 'regulation':
       case 'simple_smart_answer':
       case 'smartanswer':
-      case 'manual':
-      case 'manual_section':
+      case 'statutory_guidance':
+      case 'transaction':
+      case 'travel-advice':
         return {
           display_name: 'Guidance',
           id: 'guidance'

--- a/app/views/breadcrumb-macro.html
+++ b/app/views/breadcrumb-macro.html
@@ -6,7 +6,7 @@
         {% for page in pages %}
           <li><a href="{{ page.basePath }}/"> {{ page.title }}</a></li>
         {% endfor %}
-        <li class="current">{{ title }}</li>
+        <li class="current"><a href="#content">{{ title }}</a></li>
       </ol>
     </div>
   {% endblock %}


### PR DESCRIPTION
Prototype was missing the transaction format.

List should now match this spreadsheet: https://docs.google.com/spreadsheets/d/1LmeshaUZIda_K9Lz5c_TNs4MIIC-0GYdX-CwvlgNjvY/edit#gid=0

Do we need both `detailed_guidance` and `detailed_guide`?