### PR TITLE
More like this

### DIFF
--- a/app/data/taxons.json
+++ b/app/data/taxons.json
@@ -1,0 +1,562 @@
+[
+  {
+    "content_id": "3cec0ac5-8a19-42b9-9468-fe5e384b3662",
+    "base_path": "/education/inspection-of-local-authority-support-for-schools"
+  },
+  {
+    "content_id": "73a9f875-3715-4661-a643-a7275de80ac8",
+    "base_path": "/education/school-complaints-and-whistleblowing"
+  },
+  {
+    "content_id": "ef3248d2-2145-4f87-b99a-589433c9b101",
+    "base_path": "/education/school-food-accommodation-transport-and-uniform"
+  },
+  {
+    "content_id": "1b3b139c-76fe-4bd4-89de-e6dcda134abd",
+    "base_path": "/education/recruiting-and-managing-non-teaching-school-staff"
+  },
+  {
+    "content_id": "059e1b97-c18b-4043-94a5-59004df8282d",
+    "base_path": "/education/school-buildings-and-land"
+  },
+  {
+    "content_id": "c2f971d6-e0b4-4b00-87a4-074d6c96b2c9",
+    "base_path": "/education/data-collection-for-pupil-data-and-school-censuses"
+  },
+  {
+    "content_id": "146758aa-55d1-4cef-935d-3ce41a128bbd",
+    "base_path": "/education/academy-intervention-notices-and-reports"
+  },
+  {
+    "content_id": "49322f0a-04e1-4d08-9e18-e096cfa3301c",
+    "base_path": "/education/school-performance-tables-and-ofsted-reports"
+  },
+  {
+    "content_id": "ada85ef4-a2b5-446d-a8cf-92da2573b86f",
+    "base_path": "/education/pupil-performance-in-schools"
+  },
+  {
+    "content_id": "dbb52b1a-55ba-498c-9097-80787ee74e24",
+    "base_path": "/education/school-performance-measures"
+  },
+  {
+    "content_id": "690ac909-3bb5-44c6-8374-0e76dc00a15b",
+    "base_path": "/education/inspection-of-british-schools-overseas"
+  },
+  {
+    "content_id": "03c31099-1b0d-41ec-834d-2460a7e2992b",
+    "base_path": "/education/inspection-of-boarding-and-residential-schools"
+  },
+  {
+    "content_id": "6690703b-ce48-4108-b5f0-75807ff3202e",
+    "base_path": "/education/inspection-of-independent-schools"
+  },
+  {
+    "content_id": "40334e3b-8ce3-48d3-96bc-fec16b43da39",
+    "base_path": "/education/inspection-of-maintained-schools-and-academies"
+  },
+  {
+    "content_id": "c6da0a94-6a82-47c3-97bb-308efda37312",
+    "base_path": "/education/inspection-of-non-maintained-schools"
+  },
+  {
+    "content_id": "1227db39-e321-4439-a514-10e4d1d0e61d",
+    "base_path": "/education/setting-up-or-changing-the-status-of-a-school"
+  },
+  {
+    "content_id": "cb910f96-f842-4cfc-9e20-d99683504529",
+    "base_path": "/education/school-admissions"
+  },
+  {
+    "content_id": "4059eb90-c85a-4eb0-8307-514daf5c4ef0",
+    "base_path": "/education/support-for-education-work-in-other-countries"
+  },
+  {
+    "content_id": "d2005b89-352f-4896-aced-1d17504330e6",
+    "base_path": "/education/education-of-disadvantaged-children"
+  },
+  {
+    "content_id": "0f92387b-f477-4592-85e6-0742f3fcf696",
+    "base_path": "/education/special-educational-needs-and-disability-send-support-in-education"
+  },
+  {
+    "content_id": "47b6ce42-0bfa-42ee-9ff1-7a9c71ee9727",
+    "base_path": "/education/pupils-and-students-with-special-educational-needs-and-disability-send"
+  },
+  {
+    "content_id": "23265b25-7ec3-4960-8517-4ff8d4d92cac",
+    "base_path": "/education/funding-and-finance-for-students"
+  },
+  {
+    "content_id": "78cfdb08-0629-42d9-80eb-edbf9b36e0c3",
+    "base_path": "/education/high-needs-funding"
+  },
+  {
+    "content_id": "dd767840-363e-43ad-8835-c9ab516633de",
+    "base_path": "/education/further-and-higher-education-skills-and-vocational-training"
+  },
+  {
+    "content_id": "e16b62e0-9c54-4547-b8c0-7589d8af3906",
+    "base_path": "/education/funding-for-special-educational-needs-and-disability-send"
+  },
+  {
+    "content_id": "ff00b8b2-dcdb-4659-93c2-291c9be354f3",
+    "base_path": "/education/teaching-and-leadership"
+  },
+  {
+    "content_id": "940e7a57-171a-4dad-b6eb-e2a5a87c9cec",
+    "base_path": "/education/school-inspections-and-performance"
+  },
+  {
+    "content_id": "fb7262b7-381d-4b24-8b0d-740b6ac42f12",
+    "base_path": "/education/special-educational-needs-and-disability-send-code-of-practice"
+  },
+  {
+    "content_id": "db605204-0f03-441b-837f-16613c6b3f8f",
+    "base_path": "/education/pupil-wellbeing-behaviour-and-attendance"
+  },
+  {
+    "content_id": "1a26ae19-00f2-4be1-b9b6-aa72876a0278",
+    "base_path": "/education/school-and-academy-financial-management-and-assurance"
+  },
+  {
+    "content_id": "d2158a98-5f85-4672-ab5e-2ff232a657b4",
+    "base_path": "/education/school-trips-and-extracurricular-activity"
+  },
+  {
+    "content_id": "09a7fc9f-c9d8-45fe-8066-1bf7a6dd4a22",
+    "base_path": "/education/school-to-school-support"
+  },
+  {
+    "content_id": "42e6e5c3-3a06-4a6f-abd4-a4b85d9c6b16",
+    "base_path": "/education/running-and-managing-a-school"
+  },
+  {
+    "content_id": "90e8a226-8d40-4c1f-91e4-36a712b34e57",
+    "base_path": "/education/school-and-academy-funding-and-provision"
+  },
+  {
+    "content_id": "ba7a0379-3dc8-4ee9-acb5-ace8e6dd42b9",
+    "base_path": "/education/school-planning"
+  },
+  {
+    "content_id": "7c75c541-403f-4cb1-9b34-4ddde816a80d",
+    "base_path": "/education/school-curriculum"
+  },
+  {
+    "content_id": "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+    "base_path": "/education"
+  },
+  {
+    "content_id": "72aed311-e76e-4b4e-88db-e14d8bedbee1",
+    "base_path": "/education/careers-guidance-in-schools"
+  },
+  {
+    "content_id": "98636b54-c677-415d-b2b2-255307ea11b8",
+    "base_path": "/education/school-governance"
+  },
+  {
+    "content_id": "1ddd7a85-6c64-4b1e-9e54-55b50a0ae3f3",
+    "base_path": "/education/primary-curriculum-key-stage-1-assessments"
+  },
+  {
+    "content_id": "dc1d6a10-7f7b-464c-bd1f-3bdb66d096d0",
+    "base_path": "/education/primary-curriculum-key-stage-1-english"
+  },
+  {
+    "content_id": "9104dfd2-4da9-4309-98dc-dc54f7d8d2db",
+    "base_path": "/education/primary-curriculum-key-stage-1-maths"
+  },
+  {
+    "content_id": "8a2141ae-2493-491c-8e5f-2bd23c1a6afe",
+    "base_path": "/education/primary-curriculum-key-stage-1-science"
+  },
+  {
+    "content_id": "b0fcf462-e6b9-44e1-9145-48f66d53c81f",
+    "base_path": "/education/primary-curriculum-key-stage-1-programmes-of-study"
+  },
+  {
+    "content_id": "07fdd985-f3ec-4f4e-a316-3f4fd491bd64",
+    "base_path": "/education/primary-curriculum-key-stage-1-tests"
+  },
+  {
+    "content_id": "bf9ba557-b3d8-4c4e-8e39-0d09466808b4",
+    "base_path": "/education/primary-curriculum-key-stage-2-assessments"
+  },
+  {
+    "content_id": "35d3e1b5-5777-4cbb-b4c7-0a20f9d6d7e2",
+    "base_path": "/education/primary-curriculum-key-stage-2-english"
+  },
+  {
+    "content_id": "6fe00099-9771-4889-8638-c7f4247a168c",
+    "base_path": "/education/primary-curriculum-key-stage-2-maths"
+  },
+  {
+    "content_id": "fed09305-c819-4139-8b05-4b5375a1a582",
+    "base_path": "/education/primary-curriculum-key-stage-2-programmes-of-study"
+  },
+  {
+    "content_id": "f5babf0a-9e91-4a70-97fb-7e4ffaee33a0",
+    "base_path": "/education/primary-curriculum-key-stage-2-science"
+  },
+  {
+    "content_id": "5b9555f5-ab27-43ec-9204-c9bf939113ec",
+    "base_path": "/education/primary-curriculum-key-stage-2-tests"
+  },
+  {
+    "content_id": "904cfd73-2707-47b8-8754-5765ec5a5b68",
+    "base_path": "/education/primary-curriculum-key-stage-1"
+  },
+  {
+    "content_id": "07299ca5-bc4d-48dd-a3f1-edd3b170bb4a",
+    "base_path": "/education/early-years-curriculum"
+  },
+  {
+    "content_id": "931dc3bb-827b-4490-8013-111689b25142",
+    "base_path": "/education/primary-curriculum-key-stage-2"
+  },
+  {
+    "content_id": "0d76003d-76ba-4af5-a19e-31ab3f8ba689",
+    "base_path": "/education/phonics"
+  },
+  {
+    "content_id": "af89d06d-db1c-4a37-a8df-63d1e308c183",
+    "base_path": "/education/key-stage-3-and-4-exam-marking-qualifications-and-results"
+  },
+  {
+    "content_id": "a28530a2-b0a3-46f9-89b9-3d98fc18e39d",
+    "base_path": "/education/secondary-curriculum-key-stage-3-and-key-stage-4-gcses"
+  },
+  {
+    "content_id": "e8f17408-2d81-468f-aad8-7486a05cd0bf",
+    "base_path": "/education/gcse-subject-content-and-requirements"
+  },
+  {
+    "content_id": "197ae5ae-7922-4dba-9104-2b0d78ec472e",
+    "base_path": "/education/as-and-a-level-subject-content-and-requirements"
+  },
+  {
+    "content_id": "cf1a5c02-ed35-48f3-9e17-c702cc23ea92",
+    "base_path": "/education/gcse-changes-and-reforms"
+  },
+  {
+    "content_id": "09e40fac-beaa-4ca9-b84e-db3bbf2c9536",
+    "base_path": "/education/key-stage-5-exam-marking-qualifications-and-results"
+  },
+  {
+    "content_id": "7d04af85-f92c-45d5-9472-d2d290f49513",
+    "base_path": "/education/as-and-a-level-changes-and-reforms"
+  },
+  {
+    "content_id": "ccadca16-a0e8-4ae2-adb0-990d93ff3445",
+    "base_path": "/education/spiritual-moral-social-and-cultural-development"
+  },
+  {
+    "content_id": "258c6e6d-4e4e-42f1-a554-30b22f2aebab",
+    "base_path": "/education/exam-regulation-and-administration"
+  },
+  {
+    "content_id": "17342ebc-04f8-434b-bcd6-be533238d02d",
+    "base_path": "/education/personal-social-health-and-economic-education"
+  },
+  {
+    "content_id": "b376d700-3928-4540-b216-683dd39fb75c",
+    "base_path": "/education/school-bullying"
+  },
+  {
+    "content_id": "f08c20eb-2c28-41d9-96ef-1678425836cd",
+    "base_path": "/education/school-discipline-and-exclusions"
+  },
+  {
+    "content_id": "e86e90e0-af4f-4cd9-8b6a-f2d177575290",
+    "base_path": "/education/home-schooling"
+  },
+  {
+    "content_id": "17fb491a-15f3-4c71-8e25-f645ff8b3ed3",
+    "base_path": "/education/school-attendance-and-absence"
+  },
+  {
+    "content_id": "c657bea7-3b82-4103-9d7c-8d9725f87ede",
+    "base_path": "/education/funding-for-different-types-of-schools-and-settings"
+  },
+  {
+    "content_id": "b82fdbdb-275e-4d84-b17a-390061b6c309",
+    "base_path": "/education/early-years-funding"
+  },
+  {
+    "content_id": "5a345486-f6ab-43a6-bced-52a7301f7273",
+    "base_path": "/education/funding-for-16-to-19-year-olds-in-schools"
+  },
+  {
+    "content_id": "1f5a3ff2-9363-4421-82f4-fa08efc9586b",
+    "base_path": "/education/alternative-provision-funding"
+  },
+  {
+    "content_id": "acd7834d-1a21-4ea7-a208-bec78ec941d8",
+    "base_path": "/education/academy-funding"
+  },
+  {
+    "content_id": "ee2b56e7-7cbe-4e8b-8797-1961240e7c80",
+    "base_path": "/education/special-schools-funding"
+  },
+  {
+    "content_id": "64d18c5f-9038-4b90-a10f-30e3c94f5657",
+    "base_path": "/education/school-places-and-capacity"
+  },
+  {
+    "content_id": "269d8d2b-5bb8-4192-a452-372c49a24829",
+    "base_path": "/education/faith-schools-funding"
+  },
+  {
+    "content_id": "dd1e5961-65c9-495b-b5e9-06035a1bc9e6",
+    "base_path": "/education/funding-for-school-buildings-and-land"
+  },
+  {
+    "content_id": "26b71ec6-c395-4e24-b456-9490cb38d74b",
+    "base_path": "/education/free-school-meals-fsm-funding"
+  },
+  {
+    "content_id": "714bc7d1-afb0-4e10-9558-268da5dbbbba",
+    "base_path": "/education/pupil-premium-and-other-school-premiums"
+  },
+  {
+    "content_id": "738e53f4-97df-4d9e-a2f1-8f733d526d84",
+    "base_path": "/education/local-authority-schools-funding"
+  },
+  {
+    "content_id": "ee6d175d-e7af-417a-9f42-d2c69df9698f",
+    "base_path": "/education/school-direct-funding"
+  },
+  {
+    "content_id": "57c6ba08-a31a-4a7a-9cd6-3d571e91f1ab",
+    "base_path": "/education/schools-forums"
+  },
+  {
+    "content_id": "f81590ba-856a-4c81-9380-8bb2804120c1",
+    "base_path": "/education/initial-teacher-training-funding"
+  },
+  {
+    "content_id": "44bd4859-8bd7-4cae-b89d-a60b3444dc7c",
+    "base_path": "/education/school-buildings-and-land-transactions"
+  },
+  {
+    "content_id": "6f204e9a-a634-4942-8486-ecc841388f5c",
+    "base_path": "/education/school-buildings-and-land-guidelines"
+  },
+  {
+    "content_id": "38955795-335d-489f-83e3-3f4e935938d3",
+    "base_path": "/education/school-insurance-and-risk-management"
+  },
+  {
+    "content_id": "6d3201e7-5222-4510-b952-706cbde0721c",
+    "base_path": "/education/academy-and-academy-trust-finance-and-reporting"
+  },
+  {
+    "content_id": "e3cb8b57-6331-419a-b344-7a8148d561cb",
+    "base_path": "/education/school-procurement"
+  },
+  {
+    "content_id": "d77fe1b6-b609-4498-a321-94a41857019a",
+    "base_path": "/education/financial-management-reporting-and-assurances-for-16-to-19-year-olds-funding"
+  },
+  {
+    "content_id": "b67afac3-0bfc-4e44-9893-951be4d05e4c",
+    "base_path": "/education/safeguarding-pupils"
+  },
+  {
+    "content_id": "bcb4bdf3-5807-4421-a427-7dfe78d5f6d5",
+    "base_path": "/education/local-authority-schools-financial-reporting-and-assurance"
+  },
+  {
+    "content_id": "394b93e1-eeb7-421d-91e1-c478cc3d635e",
+    "base_path": "/education/health-and-safety-in-schools"
+  },
+  {
+    "content_id": "65938835-a0e4-4deb-97a9-e0921818996d",
+    "base_path": "/education/pupil-mental-health-and-wellbeing"
+  },
+  {
+    "content_id": "b422afa3-8349-4bb8-a36a-81d63a19507e",
+    "base_path": "/education/alternative-provision-and-pupil-referral-units"
+  },
+  {
+    "content_id": "59ceb6a5-8cb3-4671-bee2-9b392e916298",
+    "base_path": "/education/teacher-records"
+  },
+  {
+    "content_id": "720f650a-331f-4575-9c56-376d1eaa9ca0",
+    "base_path": "/education/teaching-standards-misconduct-and-practice"
+  },
+  {
+    "content_id": "73c19fc1-d7ee-4d6c-b06e-446711ed9240",
+    "base_path": "/education/recruiting-and-managing-teachers"
+  },
+  {
+    "content_id": "651b2ef7-d5fb-4ebb-b6a9-521b3b766b01",
+    "base_path": "/education/teacher-pay-pensions-and-conditions"
+  },
+  {
+    "content_id": "c58fc0b0-50bd-4a5d-9e41-64230e191032",
+    "base_path": "/education/school-leadership"
+  },
+  {
+    "content_id": "25bc1af0-33df-40be-a668-d9b05d1dd3e4",
+    "base_path": "/education/teacher-training-and-professional-development"
+  },
+  {
+    "content_id": "9ecb4547-b2ff-446f-b583-7dcf6622796d",
+    "base_path": "/education/teacher-training-providers"
+  },
+  {
+    "content_id": "5c9372ef-8cac-4c41-b95b-6117ea052b78",
+    "base_path": "/education/student-loans-bursaries-and-sponsorship"
+  },
+  {
+    "content_id": "1255e19a-f02d-485f-8d5f-000688312bd9",
+    "base_path": "/education/financial-help-for-students-who-are-parents-or-carers"
+  },
+  {
+    "content_id": "4df47fe9-4487-4889-9eaa-d3bdc59483fd",
+    "base_path": "/education/financial-help-for-international-students-in-the-uk"
+  },
+  {
+    "content_id": "58bebb74-fae7-4c97-878b-61ff543d9d12",
+    "base_path": "/education/further-and-higher-education-courses-and-qualifications"
+  },
+  {
+    "content_id": "27af9b0f-9ddf-47e2-9103-2f6f72d9ddf7",
+    "base_path": "/education/further-education-funding"
+  },
+  {
+    "content_id": "27c5c52b-3b36-4119-b461-976197d929bf",
+    "base_path": "/education/running-a-further-or-higher-education-institution"
+  },
+  {
+    "content_id": "aaeb7f58-d410-4c42-8775-05b0bdeceeea",
+    "base_path": "/education/apprenticeships-traineeships-and-internships"
+  },
+  {
+    "content_id": "4d18c236-0124-4083-b39d-8da5226fa5c9",
+    "base_path": "/education/qualified-teacher-status-qts"
+  },
+  {
+    "content_id": "ca3c2e22-9ba0-4163-b4a6-7dbf355b9846",
+    "base_path": "/education/initial-teacher-training-itt"
+  },
+  {
+    "content_id": "f421b9c8-bc31-43d5-b443-6148731a10fd",
+    "base_path": "/education/subject-knowledge-enhancement-ske"
+  },
+  {
+    "content_id": "92f1b633-9032-4f7e-ac59-37a876a69255",
+    "base_path": "/education/national-professional-qualification-for-headship-npqh"
+  },
+  {
+    "content_id": "df9db20b-b799-4ef5-916c-6d8b9f9a00f4",
+    "base_path": "/education/apprenticeship-skills-and-standards"
+  },
+  {
+    "content_id": "ff0e8e1f-4dea-42ff-b1d5-f1ae37807af2",
+    "base_path": "/education/being-an-apprentice"
+  },
+  {
+    "content_id": "31024c7d-70a3-4d5b-bf53-a375cdab3b63",
+    "base_path": "/education/types-of-apprenticeships"
+  },
+  {
+    "content_id": "41ae5900-f8e5-4840-b58f-734631029fd6",
+    "base_path": "/education/traineeships"
+  },
+  {
+    "content_id": "84eb37d2-d5fd-4fa8-adda-1ec29a26da52",
+    "base_path": "/education/internships"
+  },
+  {
+    "content_id": "4842335f-2e17-4aa7-ade8-a9f7ca21072d",
+    "base_path": "/education/learning-records-service-lrs"
+  },
+  {
+    "content_id": "56b78356-c7bf-4460-8775-d04b590ec7ca",
+    "base_path": "/education/employers-and-training-organisations"
+  },
+  {
+    "content_id": "5b021981-2999-4da1-9a4e-03c64b70168c",
+    "base_path": "/education/careers-guidance-in-further-and-higher-education"
+  },
+  {
+    "content_id": "27e57b63-4252-4c49-b103-e73f7c6ed394",
+    "base_path": "/education/inspection-of-further-education-and-skills-providers"
+  },
+  {
+    "content_id": "2dc353bf-d481-4c81-9f8f-25e1d4bc5da9",
+    "base_path": "/education/inspection-and-performance-of-further-education-providers"
+  },
+  {
+    "content_id": "fe6904d9-2190-48c9-a89a-7976803674b0",
+    "base_path": "/education/further-education-intervention-notices-and-reports"
+  },
+  {
+    "content_id": "e43c90fb-e2d1-4c35-9a82-955b3f695047",
+    "base_path": "/education/inspection-of-residential-provision-in-further-education-colleges"
+  },
+  {
+    "content_id": "86aaefa2-52db-4d8d-911d-5fff034ed035",
+    "base_path": "/education/student-performance-in-further-education"
+  },
+  {
+    "content_id": "e2b37c87-3af0-45d7-8a39-6f15fa70408b",
+    "base_path": "/education/further-education-provider-performance-measures"
+  },
+  {
+    "content_id": "bdb7a7e0-c307-4514-a271-d7f76ee8364d",
+    "base_path": "/education/performance-data-and-ofsted-reports-of-further-education-providers"
+  },
+  {
+    "content_id": "66cc145f-9dfd-47db-bb98-457a61668d14",
+    "base_path": "/education/further-education-funding-data"
+  },
+  {
+    "content_id": "e324abdb-7100-49f7-bc22-0eba2ba1e890",
+    "base_path": "/education/dance-and-drama-funding-for-16-to-19-year-olds"
+  },
+  {
+    "content_id": "e69dc613-58af-47aa-8d8e-79708fbfe677",
+    "base_path": "/education/free-meals-for-16-to-18-year-olds"
+  },
+  {
+    "content_id": "9bb10f38-3fab-4c12-9b53-c8674e64a67f",
+    "base_path": "/education/european-social-fund-esf-and-skills-funding"
+  },
+  {
+    "content_id": "98d9143e-174f-4a72-9a9d-5c8eef101cb6",
+    "base_path": "/education/further-education-building-and-premises"
+  },
+  {
+    "content_id": "9206c81a-ab48-4325-b309-1a4e7471bd7e",
+    "base_path": "/education/further-education-financial-management-and-data-collection"
+  },
+  {
+    "content_id": "f58ba5d0-5b45-43e4-a374-c2b8b3513b1f",
+    "base_path": "/education/data-collection-for-further-education-providers"
+  },
+  {
+    "content_id": "538c61de-1de6-4fc3-8e72-a06de44e1b04",
+    "base_path": "/education/local-authority-further-education-financial-reporting-and-assurance"
+  },
+  {
+    "content_id": "d5e38302-6bb2-4b49-a99e-1ffab30e1e1e",
+    "base_path": "/education/financial-management-for-further-education-providers"
+  },
+  {
+    "content_id": "6426d1c5-93c8-4659-85d5-1f0d3368a124",
+    "base_path": "/education/education-in-prisons"
+  },
+  {
+    "content_id": "c1b4353c-c05f-494c-8f94-10f7c6959287",
+    "base_path": "/education/key-stage-5-as-and-a-levels"
+  },
+  {
+    "content_id": "e6017952-1324-4e3c-98d4-226ac0492a03",
+    "base_path": "/education/adult-and-community-learning"
+  }
+]

--- a/app/models/content_presenter.js
+++ b/app/models/content_presenter.js
@@ -3,6 +3,7 @@ var Promise = require('bluebird');
 var readFile = Promise.promisify(fs.readFile);
 var glob = Promise.promisify(require('glob'));
 
+var RelatedContent = require('./related_content.js');
 var BreadcrumbMaker = require('../../lib/js/breadcrumb_maker.js');
 var TaxonomyData = require('./taxonomy_data.js');
 var Taxon = require('./taxon.js');
@@ -43,7 +44,8 @@ class ContentPresenter {
         const presented = Promise.all([
           that.getBreadcrumbPromise(),
           that.getTaxonsPromise(),
-        ]).spread(function (breadcrumb, taxons) {
+          that.getRelatedContentPromise(),
+        ]).spread(function (breadcrumb, taxons, relatedContent) {
           return {
             title: title,
             content: content,
@@ -51,10 +53,18 @@ class ContentPresenter {
             taxons: taxons,
             isWhitehall: isWhitehall,
             isHtmlManual: isHtmlManual,
+            relatedContent: relatedContent,
           }
         })
 
         return presented;
+      });
+  }
+
+  getRelatedContentPromise () {
+    return RelatedContent.get("/" + this.basePath).
+      then(function (relatedContent) {
+        return relatedContent;
       });
   }
 

--- a/app/models/related_content.js
+++ b/app/models/related_content.js
@@ -1,0 +1,90 @@
+var fs = require('fs');
+var process = require('process');
+var https = require('https');
+var querystring = require('querystring');
+var Promise = require('bluebird');
+var TaxonomyData = require('./taxonomy_data.js');
+var readFile = Promise.promisify(fs.readFile);
+var Taxon = require('./taxon.js');
+
+class RelatedContent {
+  static esRelatedLinks (contentBasePath, parentTaxon) {
+    var queryParams = {
+      similar_to: contentBasePath,
+      start: 0,
+      count: 5,
+      filter_taxons: [parentTaxon],
+      fields: 'title,description,link'
+    }
+    var queryString = querystring.stringify(queryParams);
+    var path = "/api/search.json?" + queryString;
+
+    return new Promise((resolve, reject) =>
+      https.get({
+        host: 'www.gov.uk',
+        path: path,
+      }, function (response) {
+        var body = '';
+
+        response.on('data', function (d) {
+            body += d;
+        });
+
+        response.on('end', function () {
+          var parsed = JSON.parse(body);
+          var data = parsed.results;
+
+          resolve(data);
+        });
+
+        response.on('error', reject);
+      })
+    );
+  }
+
+  static allTaxonsPromise () {
+    var readSourceData = readFile('app/data/taxons.json');
+
+    return readSourceData.
+      then(function (data) {
+        return JSON.parse(data);
+      });
+  }
+
+  static get (contentBasePath) {
+    var that = this;
+    var allTaxons = this.allTaxonsPromise();
+    var parentTaxonsPromise = allTaxons.then(function (taxons) {
+      return TaxonomyData.get().
+        then(function (metadata) {
+          return metadata.taxons_for_content[contentBasePath.slice(1)].map(function (taxonBasePath) {
+            var parentTaxon = taxons.find(function (taxon) {
+              return taxon.base_path == taxonBasePath;
+            });
+            var contentItem = Taxon.fromMetadata(taxonBasePath, metadata);
+            contentItem.contentId = parentTaxon.content_id;
+
+            return contentItem;
+          })
+        });
+    });
+
+    return parentTaxonsPromise.then(function (parentTaxons) {
+      var searchResults = parentTaxons.map(function (parentTaxon) {
+        return that.esRelatedLinks(contentBasePath, parentTaxon.contentId).then(function (results) {
+          return {
+            results: results,
+            basePath: parentTaxon.basePath,
+            title: parentTaxon.title,
+            contentId: parentTaxon.contentId,
+            description: parentTaxon.description
+          };
+        });
+      });
+
+      return Promise.all(searchResults);
+    });
+  }
+}
+
+module.exports = RelatedContent;

--- a/app/views/_side-navigation.html
+++ b/app/views/_side-navigation.html
@@ -1,16 +1,26 @@
 <div class="related-container">
   <aside class="related" id="related">
-    <header>
-      <h2>More about</h2>
-    </header>
+    {% for taxon in presentedContent.relatedContent %}
+      <div>
+        <header>
+           <h2>More about {{ taxon.title }}</h2>
+           <p>{{ taxon.description }}</p>
+        </header>
 
-    {% for taxon in presentedContent.taxons %}
-    <nav role="navigation" aria-labelledby="parent-other">
-      <h3><a href="{{ taxon.basePath }}">{{ taxon.title }}</a></h3>
-       {% if taxon.description %}
-       <p>{{ taxon.description }}</p>
-       {% endif %}
-    </nav>
+        {% if taxon.results.length > 0 %}
+          <nav role="navigation" aria-labelledby="parent-other">
+            <ul>
+              {% for contentItem in taxon.results %}
+                <li>
+                  <a href="{{ contentItem.link }}">{{ contentItem.title }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+
+            <p><a class="reveal" href="{{ taxon.basePath }}?viewAll">See everything in {{ taxon.title }}</a></p>
+          </nav>
+        {% endif %}
+      </div>
     {% endfor %}
   </aside>
 </div>


### PR DESCRIPTION
This PR adds functionality to query Rummager for more like this results and returns those to the view, so we can display them.

It also uses a new data file that includes the content ids of the taxons. This is because the taxonomy data file currently doesn't include them and would be very time consuming to add them there.

We should revisit that decision when we are sure we are going to keep related links.

For now, this is being added so information architects can see what links are being recommended.

Trello: https://trello.com/c/0GcWhX1t/402-list-current-top-more-like-this-links-for-all-education-content

It looks like this:

<img width="1126" alt="screen shot 2017-02-15 at 12 04 59" src="https://cloud.githubusercontent.com/assets/416701/22973796/11812676-f377-11e6-8066-3609eb7c48b9.png">
