### PR TITLE
Visual updates and context removal

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -416,6 +416,7 @@
 
   .govuk-title {
     .context {
+
       a {
         color: $text-colour;
         text-decoration: underline;
@@ -429,6 +430,7 @@
           border-bottom: 10px solid transparent;
           border-right: 10px solid $black;
           margin-right: 10px;
+
         }
       }
     }
@@ -473,9 +475,19 @@
         padding-bottom: $gutter-one-third;
 
         li {
+            margin-bottom: $gutter;  
+
           h3 {
             padding-bottom: 0;
           }
+        }
+      }
+
+      h2 {
+        margin-bottom: $gutter-half;
+
+        + p {
+          margin-bottom: $gutter;
         }
       }
     }
@@ -496,7 +508,7 @@
     .topic-content {
       ul {
         li {
-          margin-bottom: $gutter-one-third;
+          margin-bottom: $gutter;
 
           h3 {
             padding-bottom: 0;


### PR DESCRIPTION
Remove `.context` breadcrumb from Desktop / Tablet viewport and update styling of back arrow based on mobile font-size.

Increase spacing between list items within parent and child topic lists

Reduce `margin-bottom` on `h2`'s inside parent and child topic contents and increase margin-bottom on the `p` if adjacent to these `h2`s