### PR TITLE
Just show parent breadcrumb on mobile views

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,30 +13,5 @@
 
     GOVUK.modules.start();
 
-    var truncateBreadcrumbs = function() {
-      var maxBreadcrumb = 4;
-      var $breadcrumbs = $('.breadcrumbs').find('li');
-      if ($breadcrumbs.length > maxBreadcrumb) {
-        $breadcrumbs.each(function(i){
-          var $this = $(this);
-          if (i > 1 && i < $breadcrumbs.length - 2) {
-            $this.hide();
-          }
-        });
-        var x = $breadcrumbs.eq(1).after('<li><a href="" class="js-toggle-breadcrumb" title="Show breadcrumbs">…</a></li>');
-        console.log(x);
-      }
-    }
-
-    truncateBreadcrumbs();
-
-    $('.js-toggle-breadcrumb').on('click', function(e){
-      e.preventDefault();
-
-      $(this).parent().hide().siblings(':hidden').show();
-    });
-
-
-
   });
 })(window);

--- a/app/assets/sass/_breadcrumbs.scss
+++ b/app/assets/sass/_breadcrumbs.scss
@@ -19,6 +19,8 @@
   }
 
   li {
+    display: none;
+
     @include core-16;
     float: left;
 
@@ -38,12 +40,40 @@
     margin-bottom: 0.4em;
     padding-left: 0.9em;
 
+    @include media(tablet) {
+      display: block;
+    }
+
     &:first-child {
       background-image: none;
       margin-left: 0;
       padding-left: 0;
     }
 
+    &:nth-last-child(2) {
+      position: relative;
+      display: block;
+      background-image: none;
+      margin-left: 0;
+      padding-left: 14px;
+
+      // Back arrow - left pointing black arrow
+      &:before {
+        content: '';
+        display: block;
+        width: 0;
+        height: 0;
+
+        border-top: 5px solid transparent;
+        border-right: 6px solid $text-colour;
+        border-bottom: 5px solid transparent;
+
+        position: absolute;
+        left: 0;
+        top: 50%;
+        margin-top: -6px;
+      }
+    }
   }
 
   a {

--- a/app/assets/sass/_breadcrumbs.scss
+++ b/app/assets/sass/_breadcrumbs.scss
@@ -73,6 +73,23 @@
         top: 50%;
         margin-top: -6px;
       }
+
+      @include media(tablet) {
+        margin-left: 0.6em;
+        padding-left: 0.9em;
+
+        background-image: file-url("separator.png");
+
+        @include device-pixel-ratio() {
+          background-image: file-url("separator-2x.png");
+          background-size: 6px 11px;
+        }
+
+        &:before {
+          content: '';
+          display: none;
+        }
+      }
     }
   }
 

--- a/app/assets/sass/_breadcrumbs.scss
+++ b/app/assets/sass/_breadcrumbs.scss
@@ -50,7 +50,7 @@
       padding-left: 0;
     }
 
-    &:nth-last-child(2) {
+    &.parent {
       position: relative;
       display: block;
       background-image: none;
@@ -83,6 +83,12 @@
         @include device-pixel-ratio() {
           background-image: file-url("separator-2x.png");
           background-size: 6px 11px;
+        }
+
+        &:first-child {
+          background-image: none;
+          margin-left: 0;
+          padding-left: 0;
         }
 
         &:before {

--- a/app/assets/sass/_breadcrumbs.scss
+++ b/app/assets/sass/_breadcrumbs.scss
@@ -1,0 +1,53 @@
+@import "colours";
+@import "typography";
+@import "shims";
+@import "url-helpers";
+
+// Breadcrumbs usage:
+//
+// .breadcrumbs {
+//    @include breadcrumbs;
+// }
+
+@mixin breadcrumbs {
+
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
+
+  ol {
+    @extend %contain-floats;
+  }
+
+  li {
+    @include core-16;
+    float: left;
+
+    background-image: file-url("separator.png");
+
+    @include device-pixel-ratio() {
+      background-image: file-url("separator-2x.png");
+      background-size: 6px 11px;
+    }
+
+    background-position: 0% 50%;
+    background-repeat: no-repeat;
+
+    list-style: none;
+
+    margin-left: 0.6em;
+    margin-bottom: 0.4em;
+    padding-left: 0.9em;
+
+    &:first-child {
+      background-image: none;
+      margin-left: 0;
+      padding-left: 0;
+    }
+
+  }
+
+  a {
+    color: $text-colour;
+  }
+
+}

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -3,6 +3,7 @@
 @import 'govuk-elements';
 
 @import 'modules/subsections';
+@import 'breadcrumbs';
 
 // Related items
 // (These styles will be moved to GOV.UK elements, duplicating here for now.)
@@ -197,14 +198,8 @@
 // fix breadcrumbs
 
 .breadcrumbs {
-   // position: absolute;
-   font-size: 16px;
-   max-width: 960px;
-   z-index: 100;
-   a {
-      color: black;
-      text-decoration: underline;
-   }
+  @include breadcrumbs;
+
    li.current {
      a {
        color: $secondary-text-colour;
@@ -214,11 +209,8 @@
 }
 #whitehall-wrapper {
    .breadcrumbs {
-      a {
-         color: black;
-         text-decoration: underline;
-      }
-
+      @include breadcrumbs;
+      
       .current {
         a {
           color: $secondary-text-colour;

--- a/app/views/breadcrumb-macro.html
+++ b/app/views/breadcrumb-macro.html
@@ -1,5 +1,4 @@
 {% macro render_breadcrumb(pages, title) %}
-  {% set max_breadcrumb = 4 %}
   {% block breadcrumb %}
     <div class="breadcrumbs">
       <ol>

--- a/app/views/breadcrumb-macro.html
+++ b/app/views/breadcrumb-macro.html
@@ -4,7 +4,7 @@
     <div class="breadcrumbs">
       <ol>
         {% for page in pages %}
-          <li><a href="{{ page.basePath }}/"> {{ page.title }}</a></li>
+          <li{% if loop.last %} class="parent"{% endif %}><a href="{{ page.basePath }}/"> {{ page.title }}</a></li>
         {% endfor %}
         <li class="current"><a href="#content">{{ title }}</a></li>
       </ol>

--- a/app/views/taxonomy/_taxon-heading.html
+++ b/app/views/taxonomy/_taxon-heading.html
@@ -1,9 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <div class="govuk-title length-long">
-        <p class="context">
-          <a href="{{ presentedTaxon.parent.basePath }}">{{ presentedTaxon.parent.title }}</a>
-        </p>
         <h1>{{ presentedTaxon.title }}</h1>
 
       <p>{{ presentedTaxon.description }}</p>


### PR DESCRIPTION
On mobile views this hides all the breadcrumbs except for the parent topic, which is styled like the back link in govuk_elements

## Before:

<img width="375" alt="before" src="https://cloud.githubusercontent.com/assets/523014/22982406/f801e8f0-f396-11e6-8607-6d5e64def768.png">

## After:

<img width="375" alt="after" src="https://cloud.githubusercontent.com/assets/523014/22982421/fda6109c-f396-11e6-94c5-322ea5773d3b.png">

## After (desktop):

<img width="1024" alt="after-desktop" src="https://cloud.githubusercontent.com/assets/523014/22982438/0825204e-f397-11e6-96cc-f323c4bb34c7.png">
