### PR TITLE
More like this scoped to guidance

### DIFF
--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var GuidanceContent = require('./guidance_content');
+
 class ContentItem {
   constructor(title, basePath, documentType, publicTimestamp, description) {
     this.title = title;
@@ -10,35 +12,14 @@ class ContentItem {
   }
 
   getHeading () {
-    switch (this.documentType) {
-      case 'answer':
-      case 'contact':
-      case 'detailed_guidance':
-      case 'detailed_guide':
-      case 'form':
-      case 'guidance':
-      case 'guide':
-      case 'licence':
-      case 'local_transaction':
-      case 'manual':
-      case 'manual_section':
-      case 'map':
-      case 'place':
-      case 'programme':
-      case 'promotional':
-      case 'regulation':
-      case 'simple_smart_answer':
-      case 'smartanswer':
-      case 'statutory_guidance':
-      case 'transaction':
-      case 'travel-advice':
-        return {
-          display_name: 'Guidance',
-          id: 'guidance'
-        };
-      default:
-        return null;
+    if (GuidanceContent.isGuidanceContent(this.documentType)) {
+      return {
+        display_name: 'Guidance',
+        id: 'guidance'
+      };
     }
+
+    return null;
   }
 }
 

--- a/app/models/guidance_content.js
+++ b/app/models/guidance_content.js
@@ -1,0 +1,35 @@
+"use strict";
+
+class GuidanceContent {
+  static guidanceDocumentTypes () {
+    return [
+      'answer',
+      'contact',
+      'detailed_guidance',
+      'detailed_guide',
+      'form',
+      'guidance',
+      'guide',
+      'licence',
+      'local_transaction',
+      'manual',
+      'manual_section',
+      'map',
+      'place',
+      'programme',
+      'promotional',
+      'regulation',
+      'simple_smart_answer',
+      'smartanswer',
+      'statutory_guidance',
+      'transaction',
+      'travel-advice'
+    ];
+  }
+
+  static isGuidanceContent (documentType) {
+    return (this.guidanceDocumentTypes().indexOf(documentType) > 0);
+  }
+}
+
+module.exports = GuidanceContent;

--- a/app/models/related_content.js
+++ b/app/models/related_content.js
@@ -1,11 +1,11 @@
 var fs = require('fs');
-var process = require('process');
 var https = require('https');
 var querystring = require('querystring');
 var Promise = require('bluebird');
 var TaxonomyData = require('./taxonomy_data.js');
 var readFile = Promise.promisify(fs.readFile);
 var Taxon = require('./taxon.js');
+var GuidanceContent = require('./guidance_content');
 
 class RelatedContent {
   static esRelatedLinks (contentBasePath, parentTaxon) {
@@ -14,6 +14,7 @@ class RelatedContent {
       start: 0,
       count: 5,
       filter_taxons: [parentTaxon],
+      filter_content_store_document_type: GuidanceContent.guidanceDocumentTypes(),
       fields: 'title,description,link'
     }
     var queryString = querystring.stringify(queryParams);


### PR DESCRIPTION
This changes "more like this" results from:

<img width="380" alt="screen shot 2017-02-15 at 16 19 21" src="https://cloud.githubusercontent.com/assets/416701/22983616/8ee24bfe-f39a-11e6-82f4-fbaef9e104be.png">

to:

<img width="357" alt="screen shot 2017-02-15 at 16 19 00" src="https://cloud.githubusercontent.com/assets/416701/22983629/965fbf92-f39a-11e6-9804-ea8aac4004cf.png">


This means that we scope "more like this" queries to:
- content that is tagged to the same taxon;
- and that is guidance.

Trello: https://trello.com/c/0GcWhX1t/402-list-current-top-more-like-this-links-for-all-education-content

This was discussed with Holly.