### PR TITLE
Limit example documents to guidance

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -5,11 +5,15 @@ var DocumentType = require('./models/document_type.js');
 var TaxonPresenter = require('./models/taxon_presenter.js');
 var TaxonomyData = require('./models/taxonomy_data.js');
 var ContentPresenter = require('./models/content_presenter.js');
+var GuidanceContent = require('./models/guidance_content.js');
 
   router.get('/', function (req, res) {
     TaxonomyData.get().
       then(function (taxonomyData) {
-        var documentTypeExamples = DocumentType.getExamples(taxonomyData.document_metadata);
+        var documentTypeExamples = DocumentType.getExamples(taxonomyData.document_metadata)
+          .filter(function(documentTypeExample) {
+            return GuidanceContent.isGuidanceContent(documentTypeExample.documentType);
+          });
         res.render('index', {
           documentTypeExamples: documentTypeExamples
         });


### PR DESCRIPTION
Filters the list of example document types on the index page to only include Guidance content.

Trello: https://trello.com/c/F4Ye1KmW/417-filter-the-document-type-examples-on-the-index-page-of-the-prototype-by-guidance