### PR TITLE
Dont show pages in document collections

### DIFF
--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -3,12 +3,19 @@
 var GuidanceContent = require('./guidance_content');
 
 class ContentItem {
-  constructor(title, basePath, documentType, publicTimestamp, description) {
+  constructor(title, basePath, documentType, publicTimestamp, description, documentCollections) {
     this.title = title;
     this.basePath = basePath;
     this.documentType = documentType;
     this.publicTimestamp = publicTimestamp;
     this.description = description;
+    this.documentCollections = documentCollections;
+  }
+
+  belongsToDocumentCollection () {
+    return (
+      this.documentCollections != undefined && this.documentCollections.length > 0
+    )
   }
 
   getHeading () {

--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -107,9 +107,13 @@ class Taxon {
         contentItem.link,
         documentType,
         new Date(publicTimestamp),
-        contentItem.description
+        contentItem.description,
+        contentItem.document_collections
       );
-      taxon.addContent(contentItemModel);
+
+      if (contentItemModel.belongsToDocumentCollection() == false) {
+        taxon.addContent(contentItemModel);
+      }
     });
 
     childTaxons.forEach(function (childTaxonBasePath) {

--- a/lib/ruby/taxon_document_fetcher.rb
+++ b/lib/ruby/taxon_document_fetcher.rb
@@ -9,7 +9,7 @@ class TaxonDocumentFetcher
     response = GdsApi.with_retries(maximum_number_of_attempts: 2) do
       DataImport.rummager.search(
         filter_taxons: taxon_content_id,
-        fields: %w(title description link format public_timestamp),
+        fields: %w(title description link format public_timestamp document_collections),
         count: 1000
       ).to_h
     end


### PR DESCRIPTION
More details in the commit messages below. This PR is basically filtering out content items that belong to document collections.

Trello: https://trello.com/c/2KDTKdo6/413-only-show-collections-on-list-pages-not-content-tagged-to-them