### PR TITLE
Surface mainstream content

### DIFF
--- a/app/models/mainstream_content.js
+++ b/app/models/mainstream_content.js
@@ -1,0 +1,60 @@
+var querystring = require('querystring');
+var https = require('https');
+var Promise = require('bluebird');
+
+class MainstreamContent {
+  static forTaxonAndDescendants(taxonId) {
+
+    var queryParams = {
+      start: 0,
+      count: 50,
+      filter_part_of_taxonomy_tree: taxonId,
+      filter_content_store_document_type: MainstreamContent.documentTypes(),
+      fields: 'title,link'
+    };
+
+    var queryString = querystring.stringify(queryParams);
+    var path = "/api/search.json?" + queryString;
+
+    return new Promise((resolve, reject) =>
+      https.get({
+        host: 'www.gov.uk',
+        path: path
+      }, function (response) {
+        var responseBody = '';
+
+        response.on('data', function (d) {
+          responseBody += d;
+        });
+
+        response.on('end', function () {
+          var parsed = JSON.parse(responseBody);
+          var results = parsed.results.sort(function (a, b) {
+            return a.title.localeCompare(b.title);
+          });
+
+          resolve(results);
+        });
+
+        response.on('error', reject);
+      })
+    );
+  }
+
+  static documentTypes() {
+    return [
+      'answer',
+      'calculator',
+      'calendar',
+      'guide',
+      'local_transaction',
+      'place',
+      'programme',
+      'simple_smart_answer',
+      'smart_answer',
+      'transaction'
+    ];
+  }
+}
+
+module.exports = MainstreamContent;

--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -3,9 +3,10 @@
 var ContentItem = require("./content_item.js");
 
 class Taxon {
-  constructor(title, basePath, description, options) {
+  constructor(title, basePath, contentId, description, options) {
     this.title = title;
     this.basePath = basePath;
+    this.contentId = contentId;
     this.description = description;
     if (typeof(options) === "undefined") {
       options = {};
@@ -23,7 +24,7 @@ class Taxon {
       }
     );
     var filteredTaxon = new Taxon(
-      this.title, this.basePath, this.description,
+      this.title, this.basePath, this.contentId, this.description,
       {
         content: filteredContent,
         children: this.children
@@ -89,7 +90,7 @@ class Taxon {
       return null;
     }
 
-    var taxon = new Taxon(taxonInformation.title, basePath, taxonInformation.description);
+    var taxon = new Taxon(taxonInformation.title, basePath, taxonInformation.content_id, taxonInformation.description);
     var contentItems = metadata.documents_in_taxon[basePath].results;
     var childTaxons = metadata.children_of_taxon[basePath];
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -31,30 +31,30 @@ var GuidanceContent = require('./models/guidance_content.js');
     }
     var viewAll = !(typeof(req.query.viewAll) === "undefined");
 
-    TaxonomyData.get().
-      then(function (taxonomyData) {
-        var presentedTaxon = new TaxonPresenter(taxonParam, taxonomyData);
+    var taxonPresenter = new TaxonPresenter(taxonParam);
+    taxonPresenter.build().then(presentTaxon);
 
-        if (viewAll) {
-          var backTo = presentedTaxon.determineBackToLink(req.url);
-          res.render('taxonomy/view-all', {
-            presentedTaxon: presentedTaxon,
-            backTo: backTo,
-          });
+    function presentTaxon(presentedTaxon) {
+      if (viewAll) {
+        var backTo = presentedTaxon.determineBackToLink(req.url);
+        res.render('taxonomy/view-all', {
+          presentedTaxon: presentedTaxon,
+          backTo: backTo,
+        });
 
-          return;
-        }
+        return;
+      }
 
-        if (presentedTaxon.isPenultimate) {
-          res.render('taxonomy/penultimate-taxon', {
-            presentedTaxon: presentedTaxon,
-          });
-        } else {
-          res.render('taxonomy/taxon', {
-            presentedTaxon: presentedTaxon,
-          });
-        }
-      });
+      if (presentedTaxon.isPenultimate) {
+        res.render('taxonomy/penultimate-taxon', {
+          presentedTaxon: presentedTaxon,
+        });
+      } else {
+        res.render('taxonomy/taxon', {
+          presentedTaxon: presentedTaxon,
+        });
+      }
+    }
   });
 
   /* The two routes below, 'static-service' and 'become-childminder' are rough

--- a/app/views/taxonomy/taxon.html
+++ b/app/views/taxonomy/taxon.html
@@ -15,27 +15,22 @@
 
     <div class="grid-row">
 
+    {% if presentedTaxon.mainstreamContent.length %}
       <div class="full-width-column top-task-container block">
 
         <div class="top-task-list">
 
           <h2>Top tasks in {{presentedTaxon.title}}</h2>
             <ul>
-              <li><a href="#">16 to 19 Bursary Fund</a></li>
-              <li><a href="#">Check if an awarding body is recognised</a></li>
-              <li><a href="#">Find a regulated qualification</a></li>
-              <li><a href="#">Report teacher misconduct</a></li>
-              <li><a href="#">What qualification levels mean</a></li>
-              <li><a href="#">16 to 19 Bursary Fund</a></li>
-              <li><a href="#">Check if an awarding body is recognised</a></li>
-              <li><a href="#">Find a regulated qualification</a></li>
-              <li><a href="#">Report teacher misconduct</a></li>
-              <li><a href="#">What qualification levels mean</a></li>
+              {% for mainstreamItem in presentedTaxon.mainstreamContent %}
+                <li><a href="{{ mainstreamItem.base_path }}">{{ mainstreamItem.title }}</a></li>
+              {% endfor %}
             </ul>
 
         </div>
 
       </div>
+    {% endif %}
 
       <div class="full-width-column">
         <nav role="navigation" class="child-topics-list">


### PR DESCRIPTION
This will populate the "Top tasks" section of a taxon page from Rummager, using the new `filter_part_of_taxonomy_tree` query.

### Trello


https://trello.com/c/5wrs1iHn/432-load-mainstream-links-from-search-for-the-prototype