### PR TITLE
Tweak mainstream content pullout layout

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -525,18 +525,18 @@ a {
   .top-task-container {
 
     .top-task-list {
+      @extend %contain-floats;
 
       h2 {
         margin: 0 0 $gutter-one-third 0;
       }
 
       ul {
-        @extend %contain-floats;
+        @include grid-column(1/2);
+        padding: 0 $gutter 0 0;
 
         li {
-          @include grid-column(1/2);
           padding: $gutter-one-third 0 0 0;
-
           a {
             @include core-16;
           }

--- a/app/views/taxonomy/taxon.html
+++ b/app/views/taxonomy/taxon.html
@@ -29,13 +29,13 @@
           <h2>Top tasks in {{presentedTaxon.title}}</h2>
             <ul>
               {% for mainstreamItem in presentedTaxon.mainstreamContent.slice(0, column_height) %}
-                <li><a href="{{ mainstreamItem.base_path }}">{{ mainstreamItem.title }}</a></li>
+                <li><a href="{{ mainstreamItem.link }}">{{ mainstreamItem.title }}</a></li>
               {% endfor %}
             </ul>
             {% if presentedTaxon.mainstreamContent.length > 5 %}
             <ul>
               {% for mainstreamItem in presentedTaxon.mainstreamContent.slice(column_height) %}
-                <li><a href="{{ mainstreamItem.base_path }}">{{ mainstreamItem.title }}</a></li>
+                <li><a href="{{ mainstreamItem.link }}">{{ mainstreamItem.title }}</a></li>
               {% endfor %}
             </ul>
             {% endif %}

--- a/app/views/taxonomy/taxon.html
+++ b/app/views/taxonomy/taxon.html
@@ -21,7 +21,7 @@
         <div class="top-task-list">
 
           {% if presentedTaxon.mainstreamContent.length > 10 %}
-            {% set column_height = presentedTaxon.mainstreamContent.length/2 | round(0, "ceil") %}
+            {% set column_height = (presentedTaxon.mainstreamContent.length/2) | round(0, "ceil") %}
           {% else %}
             {% set column_height = 5 %}
           {% endif %}

--- a/app/views/taxonomy/taxon.html
+++ b/app/views/taxonomy/taxon.html
@@ -16,17 +16,29 @@
     <div class="grid-row">
 
     {% if presentedTaxon.mainstreamContent.length %}
-      <div class="full-width-column top-task-container block">
+      <div class="full-width-column top-task-container lines">
 
         <div class="top-task-list">
 
+          {% if presentedTaxon.mainstreamContent.length > 10 %}
+            {% set column_height = presentedTaxon.mainstreamContent.length/2 | round(0, "ceil") %}
+          {% else %}
+            {% set column_height = 5 %}
+          {% endif %}
+
           <h2>Top tasks in {{presentedTaxon.title}}</h2>
             <ul>
-              {% for mainstreamItem in presentedTaxon.mainstreamContent %}
+              {% for mainstreamItem in presentedTaxon.mainstreamContent.slice(0, column_height) %}
                 <li><a href="{{ mainstreamItem.base_path }}">{{ mainstreamItem.title }}</a></li>
               {% endfor %}
             </ul>
-
+            {% if presentedTaxon.mainstreamContent.length > 5 %}
+            <ul>
+              {% for mainstreamItem in presentedTaxon.mainstreamContent.slice(column_height) %}
+                <li><a href="{{ mainstreamItem.base_path }}">{{ mainstreamItem.title }}</a></li>
+              {% endfor %}
+            </ul>
+            {% endif %}
         </div>
 
       </div>


### PR DESCRIPTION
* use bordered style instead of box
* flow lists vertically
* balance column height

This will use two lists when there is more than 5 mainstream content items which could introduce issues for screen reader users, so the markup will need to be tested before going live

### Screenshots:

![screen shot 2017-02-24 at 18 16 36](https://cloud.githubusercontent.com/assets/523014/23315459/3ab1e582-fabe-11e6-963f-65e45daa8208.png)

![screen shot 2017-02-24 at 18 18 09](https://cloud.githubusercontent.com/assets/523014/23315462/3df1cfaa-fabe-11e6-92d3-dc2daf8d0796.png)

![screen shot 2017-02-24 at 18 18 27](https://cloud.githubusercontent.com/assets/523014/23315468/4138191c-fabe-11e6-9888-ae4c7be7c52f.png)

![screen shot 2017-02-24 at 18 22 00](https://cloud.githubusercontent.com/assets/523014/23315471/44d88e8a-fabe-11e6-8018-ccf6bf5d84f1.png)
