### PR TITLE
Fix the layout of document collections

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -68,7 +68,7 @@ a {
     padding: 0;
   }
 
-  .detailed-guide {
+  .detailed-guide, .document-collection {
     @include grid-column(2/3);
 
     .govuk-breadcrumbs {
@@ -418,7 +418,7 @@ a {
 
   .govuk-title {
     .context {
-      
+
       a {
         color: $text-colour;
         text-decoration: underline;
@@ -468,7 +468,7 @@ a {
   }
 
   .parent-topic-contents {
-    
+
     @include grid-column(2/3);
 
     .topic-content {


### PR DESCRIPTION
### Before

<img width="1132" alt="screen shot 2017-02-28 at 10 35 35" src="https://cloud.githubusercontent.com/assets/416701/23401998/b5c19dea-fda1-11e6-8f92-852e0487d6c9.png">

### After

<img width="1085" alt="screen shot 2017-02-28 at 10 35 27" src="https://cloud.githubusercontent.com/assets/416701/23402002/b8516f22-fda1-11e6-9872-0da7f5c0140d.png">

Note: the list items in the side nav are being fixed by @alextea in another PR.

Trello: https://trello.com/c/sP4dW3qI/450-find-out-why-a-statutory-guidance-page-doesn-t-display-new-navigation-and-isn-t-in-the-accordion-view-in-the-prototype

Page to test: /government/collections/health-and-safety-in-schools