### PR TITLE
Override the layout for publications

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -298,6 +298,9 @@ a {
   }
 }
 
+.govuk-metadata,
+.related-information,
+.history-information,
 .primary-metadata,
 #whitehall-wrapper .metadata-list,
 .status-block,

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -68,7 +68,7 @@ a {
     padding: 0;
   }
 
-  .detailed-guide, .document-collection {
+  .detailed-guide, .document-collection, .publication {
     @include grid-column(2/3);
 
     .govuk-breadcrumbs {


### PR DESCRIPTION
This will include any guidance content.

### Before

<img width="1095" alt="screen shot 2017-02-28 at 10 51 20" src="https://cloud.githubusercontent.com/assets/416701/23402565/004cb7a8-fda4-11e6-92ae-204287389c50.png">

### After

<img width="1036" alt="screen shot 2017-02-28 at 11 32 29" src="https://cloud.githubusercontent.com/assets/416701/23403784/a04bd752-fda9-11e6-8a23-b015acd17ba2.png">

