### PR TITLE
Look for the document type in all guidance array

### DIFF
--- a/app/models/guidance_content.js
+++ b/app/models/guidance_content.js
@@ -29,7 +29,7 @@ class GuidanceContent {
   }
 
   static isGuidanceContent (documentType) {
-    return (this.guidanceDocumentTypes().indexOf(documentType) > 0);
+    return (this.guidanceDocumentTypes().indexOf(documentType) >= 0);
   }
 }
 


### PR DESCRIPTION
We were previously ignoring the first element of the guidance array.