### PR TITLE
Manually add subsections of "What qualification levels mean"

### DIFF
--- a/app/content/guide/what-different-qualification-levels-mean-compare-different-qualification-levels.html
+++ b/app/content/guide/what-different-qualification-levels-mean-compare-different-qualification-levels.html
@@ -1,0 +1,115 @@
+<main class="multi-page" id="content" role="main">
+ <header class="page-header">
+  <div>
+   <h1>
+    What qualification levels mean
+   </h1>
+  </div>
+ </header>
+ <div class="article-container group">
+  <div class="content-block">
+   <div class="inner">
+    <aside>
+     <div class="inner">
+      <nav aria-label="parts to this guide" class="page-navigation" role="navigation">
+       <ol>
+        <li>
+         <span class="part-number">
+          1.
+         </span>
+         <a href="/what-different-qualification-levels-mean-overview" title="Part 1: Overview">
+          Overview
+         </a>
+        </li>
+        <li>
+         <span class="part-number">
+          2.
+         </span>
+         <a href="/what-different-qualification-levels-mean-list-of-qualification-levels" title="Part 2: England, Wales and Northern Ireland">
+          England, Wales and Northern Ireland
+         </a>
+        </li>
+        <li class="active">
+         <span class="part-number">
+          3.
+         </span>
+         <span>
+          Other countries
+         </span>
+        </li>
+       </ol>
+      </nav>
+     </div>
+    </aside>
+    <header>
+     <h1>
+      3. Other countries
+     </h1>
+    </header>
+    <p>
+     Qualifications outside England, Wales and Northern Ireland use different level systems.
+    </p>
+    <h2 id="scotland">
+     Scotland
+    </h2>
+    <p>
+     You can
+     <a href="http://www.scqf.org.uk/" rel="external">
+      compare qualifications in Scotland
+     </a>
+     with those in England, Wales and Northern Ireland.
+    </p>
+    <h2 id="outside-the-uk">
+     Outside the UK
+    </h2>
+    <p>
+     You can:
+    </p>
+    <ul>
+     <li>
+      <a href="http://ec.europa.eu/ploteus/search/site?f%5B0%5D=im_field_entity_type%3A97" rel="external">
+       compare European qualifications
+      </a>
+     </li>
+     <li>
+      contact the
+      <a href="http://naric.org.uk/UK%20NCP/Contact%20Us.aspx" rel="external">
+       UK National Academic Recognition Information Centre (
+       <abbr title="UK National Academic Recognition Information Centre">
+        UK NARIC
+       </abbr>
+       )
+      </a>
+      to compare a UK qualification with any non-UK qualification - there’s a fee for this
+     </li>
+    </ul>
+    <footer>
+     <nav aria-label="Pagination" class="pagination" role="navigation">
+      <ul class="group">
+       <li class="previous">
+        <a href="/what-different-qualification-levels-mean/list-of-qualification-levels" rel="prev" title="Navigate to previous part">
+         <span class="pagination-label">
+          Previous
+         </span>
+         <span class="pagination-part-title">
+          England, Wales and Northern Ireland
+         </span>
+        </a>
+       </li>
+      </ul>
+     </nav>
+    </footer>
+    <div class="print-link">
+     <a href="/what-different-qualification-levels-mean/print" rel="nofollow">
+      Print entire guide
+     </a>
+    </div>
+   </div>
+  </div>
+  <div class="meta-data group">
+   <p class="modified-date">
+    Last updated: 27 February 2017
+   </p>
+  </div>
+ </div>
+</main>

--- a/app/content/guide/what-different-qualification-levels-mean-list-of-qualification-levels.html
+++ b/app/content/guide/what-different-qualification-levels-mean-list-of-qualification-levels.html
@@ -1,0 +1,502 @@
+<main class="multi-page" id="content" role="main">
+ <header class="page-header">
+  <div>
+   <h1>
+    What qualification levels mean
+   </h1>
+  </div>
+ </header>
+ <div class="article-container group">
+  <div class="content-block">
+   <div class="inner">
+    <aside>
+     <div class="inner">
+      <nav aria-label="parts to this guide" class="page-navigation" role="navigation">
+       <ol>
+        <li>
+         <span class="part-number">
+          1.
+         </span>
+         <a href="/what-different-qualification-levels-mean-overview" title="Part 1: Overview">
+          Overview
+         </a>
+        </li>
+        <li class="active">
+         <span class="part-number">
+          2.
+         </span>
+         <span>
+          England, Wales and Northern Ireland
+         </span>
+        </li>
+        <li>
+         <span class="part-number">
+          3.
+         </span>
+         <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels" title="Part 3: Other countries">
+          Other countries
+         </a>
+        </li>
+       </ol>
+      </nav>
+     </div>
+    </aside>
+    <header>
+     <h1>
+      2. England, Wales and Northern Ireland
+     </h1>
+    </header>
+    <p>
+     There are 9 qualification levels.
+    </p>
+    <h2 id="entry-level">
+     Entry level
+    </h2>
+    <p>
+     Each entry level qualification is available at three sub-levels - 1, 2 and 3. Entry level 3 is the most difficult.
+    </p>
+    <p>
+     Entry level qualifications are:
+    </p>
+    <ul>
+     <li>
+      entry level award
+     </li>
+     <li>
+      entry level certificate (
+      <abbr title="Entry level certificate">
+       ELC
+      </abbr>
+      )
+     </li>
+     <li>
+      entry level diploma
+     </li>
+     <li>
+      entry level English for speakers of other languages (
+      <abbr title="English for speakers of other languages">
+       ESOL
+      </abbr>
+      )
+     </li>
+     <li>
+      entry level essential skills
+     </li>
+     <li>
+      entry level functional skills
+     </li>
+     <li>
+      Skills for Life
+     </li>
+    </ul>
+    <h2 id="level-1">
+     Level 1
+    </h2>
+    <p>
+     Level 1 qualifications are:
+    </p>
+    <ul>
+     <li>
+      first certificate
+     </li>
+     <li>
+      GCSE - grade D, E, F or G
+     </li>
+     <li>
+      level 1 award
+     </li>
+     <li>
+      level 1 certificate
+     </li>
+     <li>
+      level 1 diploma
+     </li>
+     <li>
+      level 1
+      <abbr title="English for speakers of other languages">
+       ESOL
+      </abbr>
+     </li>
+     <li>
+      level 1 essential skills
+     </li>
+     <li>
+      level 1 functional skills
+     </li>
+     <li>
+      level 1 national vocational qualification (
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+      )
+     </li>
+     <li>
+      music grades 1, 2 and 3
+     </li>
+    </ul>
+    <h2 id="level-2">
+     Level 2
+    </h2>
+    <p>
+     Level 2 qualifications are:
+    </p>
+    <ul>
+     <li>
+      CSE - grade 1
+     </li>
+     <li>
+      GCSE - grade A*, A, B or C
+     </li>
+     <li>
+      intermediate apprenticeship
+     </li>
+     <li>
+      level 2 award
+     </li>
+     <li>
+      level 2 certificate
+     </li>
+     <li>
+      level 2 diploma
+     </li>
+     <li>
+      level 2
+      <abbr title="English for speakers of other languages">
+       ESOL
+      </abbr>
+     </li>
+     <li>
+      level 2 essential skills
+     </li>
+     <li>
+      level 2 functional skills
+     </li>
+     <li>
+      level 2 national certificate
+     </li>
+     <li>
+      level 2 national diploma
+     </li>
+     <li>
+      level 2
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+     <li>
+      music grades 4 and 5
+     </li>
+     <li>
+      O level - grade A, B or C
+     </li>
+    </ul>
+    <h2 id="level-3">
+     Level 3
+    </h2>
+    <p>
+     Level 3 qualifications are:
+    </p>
+    <ul>
+     <li>
+      A level - grade A, B, C, D or E
+     </li>
+     <li>
+      access to higher education diploma
+     </li>
+     <li>
+      advanced apprenticeship
+     </li>
+     <li>
+      applied general
+     </li>
+     <li>
+      <abbr title="Advanced Subsidiary">
+       AS
+      </abbr>
+      level
+     </li>
+     <li>
+      international Baccalaureate diploma
+     </li>
+     <li>
+      level 3 award
+     </li>
+     <li>
+      level 3 certificate
+     </li>
+     <li>
+      level 3 diploma
+     </li>
+     <li>
+      level 3
+      <abbr title="English for speakers of other languages">
+       ESOL
+      </abbr>
+     </li>
+     <li>
+      level 3 national certificate
+     </li>
+     <li>
+      level 3 national diploma
+     </li>
+     <li>
+      level 3
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+     <li>
+      music grades 6, 7 and 8
+     </li>
+     <li>
+      tech level
+     </li>
+    </ul>
+    <h2 id="level-4">
+     Level 4
+    </h2>
+    <p>
+     Level 4 qualifications are:
+    </p>
+    <ul>
+     <li>
+      certificate of higher education (
+      <abbr title="Certificate of higher education">
+       CertHE
+      </abbr>
+      )
+     </li>
+     <li>
+      higher apprenticeship
+     </li>
+     <li>
+      higher national certificate (
+      <abbr title="Higher national certificate">
+       HNC
+      </abbr>
+      )
+     </li>
+     <li>
+      level 4 award
+     </li>
+     <li>
+      level 4 certificate
+     </li>
+     <li>
+      level 4 diploma
+     </li>
+     <li>
+      level 4
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+    </ul>
+    <h2 id="level-5">
+     Level 5
+    </h2>
+    <p>
+     Level 5 qualifications are:
+    </p>
+    <ul>
+     <li>
+      diploma of higher education (
+      <abbr title="Diploma of higher education">
+       DipHE
+      </abbr>
+      )
+     </li>
+     <li>
+      foundation degree
+     </li>
+     <li>
+      higher national diploma (
+      <abbr title="Higher national diploma">
+       HND
+      </abbr>
+      )
+     </li>
+     <li>
+      level 5 award
+     </li>
+     <li>
+      level 5 certificate
+     </li>
+     <li>
+      level 5 diploma
+     </li>
+     <li>
+      level 5
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+    </ul>
+    <h2 id="level-6">
+     Level 6
+    </h2>
+    <p>
+     Level 6 qualifications are:
+    </p>
+    <ul>
+     <li>
+      degree apprenticeship
+     </li>
+     <li>
+      degree with honours - for example bachelor of the arts (
+      <abbr title="Bachelor of the Arts">
+       BA
+      </abbr>
+      ) hons, bachelor of science (
+      <abbr title="Bachelor of science">
+       BSc
+      </abbr>
+      ) hons
+     </li>
+     <li>
+      graduate certificate
+     </li>
+     <li>
+      graduate diploma
+     </li>
+     <li>
+      level 6 award
+     </li>
+     <li>
+      level 6 certificate
+     </li>
+     <li>
+      level 6 diploma
+     </li>
+     <li>
+      level 6
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+     <li>
+      ordinary degree without honours
+     </li>
+    </ul>
+    <h2 id="level-7">
+     Level 7
+    </h2>
+    <p>
+     Level 7 qualifications are:
+    </p>
+    <ul>
+     <li>
+      integrated master’s degree, for example master of engineering (
+      <abbr title="Master of engineering">
+       MEng
+      </abbr>
+      )
+     </li>
+     <li>
+      level 7 award
+     </li>
+     <li>
+      level 7 certificate
+     </li>
+     <li>
+      level 7 diploma
+     </li>
+     <li>
+      level 7
+      <abbr title="National vocational qualification">
+       NVQ
+      </abbr>
+     </li>
+     <li>
+      master’s degree, for example master of arts (
+      <abbr title="Master of arts">
+       MA
+      </abbr>
+      ), master of science (
+      <abbr title="Master of science">
+       MSc
+      </abbr>
+      )
+     </li>
+     <li>
+      postgraduate certificate
+     </li>
+     <li>
+      postgraduate certificate in education (
+      <abbr title="Postgraduate certificate in education">
+       PGCE
+      </abbr>
+      )
+     </li>
+     <li>
+      postgraduate diploma
+     </li>
+    </ul>
+    <h2 id="level-8">
+     Level 8
+    </h2>
+    <p>
+     Level 8 qualifications are:
+    </p>
+    <ul>
+     <li>
+      doctorate, for example doctor of philosophy (
+      <abbr title="Doctor of philosophy">
+       PhD
+      </abbr>
+      or
+      <abbr title="Doctor of philosophy">
+       DPhil
+      </abbr>
+      )
+     </li>
+     <li>
+      level 8 award
+     </li>
+     <li>
+      level 8 certificate
+     </li>
+     <li>
+      level 8 diploma
+     </li>
+    </ul>
+    <footer>
+     <nav aria-label="Pagination" class="pagination" role="navigation">
+      <ul class="group">
+       <li class="previous">
+        <a href="/what-different-qualification-levels-mean-overview" rel="prev" title="Navigate to previous part">
+         <span class="pagination-label">
+          Previous
+         </span>
+         <span class="pagination-part-title">
+          Overview
+         </span>
+        </a>
+       </li>
+       <li class="next">
+        <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels" rel="next" title="Navigate to next part">
+         <span class="pagination-label">
+          Next
+         </span>
+         <span class="pagination-part-title">
+          Other countries
+         </span>
+        </a>
+       </li>
+      </ul>
+     </nav>
+    </footer>
+    <div class="print-link">
+     <a href="/what-different-qualification-levels-mean/print" rel="nofollow">
+      Print entire guide
+     </a>
+    </div>
+   </div>
+  </div>
+  <div class="meta-data group">
+   <p class="modified-date">
+    Last updated: 27 February 2017
+   </p>
+  </div>
+ </div>
+</main>

--- a/app/content/guide/what-different-qualification-levels-mean-overview.html
+++ b/app/content/guide/what-different-qualification-levels-mean-overview.html
@@ -1,0 +1,183 @@
+<main class="multi-page" id="content" role="main">
+ <header class="page-header">
+  <div>
+   <h1>
+    What qualification levels mean
+   </h1>
+  </div>
+ </header>
+ <div class="article-container group">
+  <div class="content-block">
+   <div class="inner">
+    <aside>
+     <div class="inner">
+      <nav aria-label="parts to this guide" class="page-navigation" role="navigation">
+       <ol>
+        <li class="active">
+         <span class="part-number">
+          1.
+         </span>
+         <span>
+          Overview
+         </span>
+        </li>
+        <li>
+         <span class="part-number">
+          2.
+         </span>
+         <a href="/what-different-qualification-levels-mean-list-of-qualification-levels" title="Part 2: England, Wales and Northern Ireland">
+          England, Wales and Northern Ireland
+         </a>
+        </li>
+        <li>
+         <span class="part-number">
+          3.
+         </span>
+         <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels" title="Part 3: Other countries">
+          Other countries
+         </a>
+        </li>
+       </ol>
+      </nav>
+     </div>
+    </aside>
+    <header>
+     <h1>
+      1. Overview
+     </h1>
+    </header>
+    <p>
+     Most qualifications have a difficulty level. The higher the level, the more difficult the qualification is.
+    </p>
+    <p>
+     If you need to know the level of a qualification, you can:
+    </p>
+    <ul>
+     <li>
+      see a list of
+      <a href="/what-different-qualification-levels-mean-list-of-qualification-levels">
+       qualification levels
+      </a>
+      in England, Wales and Northern Ireland
+     </li>
+     <li>
+      use the
+      <a href="/find-a-regulated-qualification">
+       Register of Regulated Qualifications
+      </a>
+      - if you know the name of the qualification and the exam board that runs it
+     </li>
+     <li>
+      <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels">
+       compare qualification levels
+      </a>
+      from other countries
+     </li>
+    </ul>
+    <p>
+     Qualifications at the same level sometimes cover different amounts of the same subject.
+    </p>
+    <div class="example">
+     <p>
+      <strong>
+       Example
+      </strong>
+      <abbr title="Advanced Subsidiary">
+       AS
+      </abbr>
+      levels and A levels are both level 3, but you study
+      <abbr title="Advanced Subsidiary">
+       AS
+      </abbr>
+      levels over 1 year and A levels over 2 years. So you learn more about the subject at A level.
+     </p>
+    </div>
+    <h2 id="help">
+     Help
+    </h2>
+    <p>
+     Contact the National Careers Service for advice about qualification levels if you’re in England.
+    </p>
+    <div class="contact">
+     <p>
+      <strong>
+       National Careers Service
+      </strong>
+      <br>
+       <a href="http://nationalcareersservice.direct.gov.uk">
+        National Careers Service website
+       </a>
+       <br>
+        <a href="https://nationalcareersservice.direct.gov.uk/aboutus/contactus/Pages/adviser.aspx">
+         Email a careers adviser
+        </a>
+        <br>
+         <a href="http://nationalcareersservice.phoneme.net">
+          Arrange for a careers adviser to call you
+         </a>
+         <br>
+          Telephone: 0800 100 900
+          <br>
+           Monday to Sunday, 8am to 10pm
+           <br>
+            <a href="/call-charges">
+             Find out about call charges
+            </a>
+           </br>
+          </br>
+         </br>
+        </br>
+       </br>
+      </br>
+     </p>
+    </div>
+    <p>
+     For the rest of the UK, contact:
+    </p>
+    <ul>
+     <li>
+      <a href="https://www.myworldofwork.co.uk/" rel="external">
+       Skills Development Scotland
+      </a>
+     </li>
+     <li>
+      <a href="http://www.careerswales.com/" rel="external">
+       Careers Wales
+      </a>
+     </li>
+     <li>
+      <a href="https://www.nidirect.gov.uk/campaigns/careers" rel="external">
+       Northern Ireland Direct
+      </a>
+     </li>
+    </ul>
+    <footer>
+     <nav aria-label="Pagination" class="pagination" role="navigation">
+      <ul class="group">
+       <li class="next">
+        <a href="/what-different-qualification-levels-mean/list-of-qualification-levels" rel="next" title="Navigate to next part">
+         <span class="pagination-label">
+          Next
+         </span>
+         <span class="pagination-part-title">
+          England, Wales and Northern Ireland
+         </span>
+        </a>
+       </li>
+      </ul>
+     </nav>
+    </footer>
+    <div class="print-link">
+     <a href="/what-different-qualification-levels-mean/print" rel="nofollow">
+      Print entire guide
+     </a>
+    </div>
+   </div>
+  </div>
+  <div class="meta-data group">
+   <p class="modified-date">
+    Last updated: 27 February 2017
+   </p>
+  </div>
+ </div>
+</main>

--- a/app/content/guide/what-different-qualification-levels-mean.html
+++ b/app/content/guide/what-different-qualification-levels-mean.html
@@ -25,7 +25,7 @@
          <span class="part-number">
           2.
          </span>
-         <a href="/what-different-qualification-levels-mean/list-of-qualification-levels" title="Part 2: England, Wales and Northern Ireland">
+         <a href="/what-different-qualification-levels-mean-list-of-qualification-levels" title="Part 2: England, Wales and Northern Ireland">
           England, Wales and Northern Ireland
          </a>
         </li>
@@ -33,7 +33,7 @@
          <span class="part-number">
           3.
          </span>
-         <a href="/what-different-qualification-levels-mean/compare-different-qualification-levels" title="Part 3: Other countries">
+         <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels" title="Part 3: Other countries">
           Other countries
          </a>
         </li>
@@ -55,7 +55,7 @@
     <ul>
      <li>
       see a list of
-      <a href="/what-different-qualification-levels-mean/list-of-qualification-levels">
+      <a href="/what-different-qualification-levels-mean-list-of-qualification-levels">
        qualification levels
       </a>
       in England, Wales and Northern Ireland
@@ -68,7 +68,7 @@
       - if you know the name of the qualification and the exam board that runs it
      </li>
      <li>
-      <a href="/what-different-qualification-levels-mean/compare-different-qualification-levels">
+      <a href="/what-different-qualification-levels-mean-compare-different-qualification-levels">
        compare qualification levels
       </a>
       from other countries

--- a/app/models/content_item.js
+++ b/app/models/content_item.js
@@ -12,6 +12,16 @@ class ContentItem {
     this.documentCollections = documentCollections;
   }
 
+  isSubsection () {
+    return(
+      [
+        "/what-different-qualification-levels-mean-overview",
+        "/what-different-qualification-levels-mean-list-of-qualification-levels",
+        "/what-different-qualification-levels-mean-compare-different-qualification-levels",
+      ].includes(this.basePath)
+    )
+  }
+
   belongsToDocumentCollection () {
     return (
       this.documentCollections != undefined && this.documentCollections.length > 0

--- a/app/models/taxon.js
+++ b/app/models/taxon.js
@@ -112,7 +112,8 @@ class Taxon {
         contentItem.document_collections
       );
 
-      if (contentItemModel.belongsToDocumentCollection() == false) {
+      if (contentItemModel.isSubsection() == false &&
+          contentItemModel.belongsToDocumentCollection() == false) {
         taxon.addContent(contentItemModel);
       }
     });


### PR DESCRIPTION
![new-pages-added](https://cloud.githubusercontent.com/assets/416701/23512027/21a12830-ff57-11e6-9533-30083d4b6f49.gif)

Trello: https://trello.com/c/olmnvEoO/456-showing-the-second-chapter-of-the-guide-what-qualification-levels-mean-in-the-prototype

I had to manually add these sub-sections as pages because they are not content items and therefore can't be tagged/fetched like other pages. This is only needed for the accessibility rounds.

Page that links to those new 3 pages: https://govuk-nav-prototype-pr-147.herokuapp.com/what-different-qualification-levels-mean