### PR TITLE
Remove document collection from practitioners' guide

### DIFF
--- a/app/data/taxonomy_data.json
+++ b/app/data/taxonomy_data.json
@@ -18128,12 +18128,6 @@
           "format": "publication",
           "public_timestamp": "2015-03-26T12:17:00.000+00:00",
           "document_collections": [
-            {
-              "slug": "departmental-advice-schools",
-              "title": "Schools: departmental advice",
-              "content_id": "5ef4d489-7631-11e4-a3cb-005056011aef",
-              "link": "/government/collections/departmental-advice-schools"
-            }
           ],
           "index": "government",
           "es_score": null,

--- a/app/models/content_presenter.js
+++ b/app/models/content_presenter.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var fs = require('fs');
 var Promise = require('bluebird');
 var readFile = Promise.promisify(fs.readFile);
@@ -64,7 +65,7 @@ class ContentPresenter {
   getRelatedContentPromise () {
     return RelatedContent.get("/" + this.basePath).
       then(function (relatedContent) {
-        return relatedContent;
+        return _.sortBy(relatedContent, "title");
       });
   }
 


### PR DESCRIPTION
This will allow it to show up in the taxon list.

In the list now:

<img width="1121" alt="screen shot 2017-03-21 at 09 33 59" src="https://cloud.githubusercontent.com/assets/416701/24140903/92fe71ec-0e19-11e7-882e-cd787473c3e1.png">

And the side bar is sorted by taxon title too:

<img width="1098" alt="screen shot 2017-03-21 at 09 34 07" src="https://cloud.githubusercontent.com/assets/416701/24140913/99be691a-0e19-11e7-8103-cb529f1fff89.png">
