### PR TITLE
Jump to the next route when the theme is invalid

### DIFF
--- a/app/models/taxon_presenter.js
+++ b/app/models/taxon_presenter.js
@@ -8,6 +8,12 @@ class TaxonPresenter {
     this.basePath = taxonParam;
   }
 
+  // For now, the only valid theme is Education. There is no way of determining
+  // taxon themes programatically yet, so they still need to be hardcoded.
+  static isValidTheme (theme) {
+    return ['education'].includes(theme);
+  }
+
   build() {
     return Promise.resolve(this)
       .then(function(presentedTaxon) {

--- a/app/routes/taxons.js
+++ b/app/routes/taxons.js
@@ -1,7 +1,11 @@
 var TaxonPresenter = require('../models/taxon_presenter.js');
 
 class TaxonRoutes {
-  static show (req, res) {
+  static show (req, res, next) {
+    if(!TaxonPresenter.isValidTheme(req.params.theme)) {
+      return next();
+    }
+
     var theme = "/" + req.params.theme;
     var taxonParam = req.params.taxon;
 


### PR DESCRIPTION
We need a way to know if we are navigating to a taxon theme page (e.g.
/education) or a content page such as /apply-online-for-student-finance.

In order to do that, we allow the taxon routes to jump to the next
available routing handler when the :theme param is invalid, i.e. not a
valid theme.

Trello: https://trello.com/c/FtxefRxm/38-tidy-up-routes-js