### PR TITLE
Log `Promise` rejections at the routing layer and exit

### DIFF
--- a/app/models/document_types.js
+++ b/app/models/document_types.js
@@ -22,6 +22,10 @@ class DocumentTypes {
           .filter(function (documentTypeExample) {
             return GuidanceContent.isGuidanceContent(documentTypeExample.documentType);
           });
+      })
+      .catch(function (error) {
+        console.error((new Error(error)).stack);
+        process.exit(1);
       });
   }
 }

--- a/app/routes/content_items.js
+++ b/app/routes/content_items.js
@@ -11,9 +11,10 @@ class ContentItemRoutes {
           presentedContent: presentedContent,
         })
       }).
-      catch(function () {
-        res.status(404).render('404');
-      })
+      catch(function (error) {
+        console.error((new Error(error)).stack);
+        process.exit(1);
+      });
   }
 }
 

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -16,6 +16,10 @@ class SearchRoutes {
           scopedSearch: scopedSearchResults,
           allGovUkResultsCount: allResults
         });
+      })
+      .catch(function (error) {
+        console.error((new Error(error)).stack);
+        process.exit(1);
       });
   }
 }

--- a/app/routes/site.js
+++ b/app/routes/site.js
@@ -8,7 +8,11 @@ class SiteRoutes {
           'index',
           {documentTypeExamples: guidanceExamples}
         );
-    });
+      })
+      .catch(function (error) {
+        console.error((new Error(error)).stack);
+        process.exit(1);
+      });;
   }
 
   static home (req, res) {

--- a/app/routes/taxons.js
+++ b/app/routes/taxons.js
@@ -16,7 +16,12 @@ class TaxonRoutes {
       taxonParam = theme + "/" + taxonParam;
     }
 
-    TaxonPresenter.build(taxonParam).then(presentTaxon);
+    TaxonPresenter.build(taxonParam)
+      .then(presentTaxon)
+      .catch(function (error) {
+        console.error((new Error(error)).stack);
+        process.exit(1);
+      });
 
     function presentTaxon(taxon) {
       if (taxon.hasGrandchildren) {

--- a/app/services/https.js
+++ b/app/services/https.js
@@ -57,7 +57,7 @@ class Https {
 
         function fail(message) {
           reject(
-            `Error fetching  ${options.host}${options.path}
+            `Error fetching https://${options.host}${options.path}
              HTTP Status Code: ${response.statusCode}
              ${message || ''}
              === RESPONSE BODY ===


### PR DESCRIPTION
We previously had no handling of `Promise` rejections. This is a simple
change that adds basic logging of the error and identifies the router
that failed. We quit the application to make it obvious that something
has gone wrong.